### PR TITLE
Refactor integration tests to use pytest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Shared pytest fixtures for RMCP tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rmcp.core.context import Context
+from rmcp.core.server import create_server
+from rmcp.registries.tools import register_tool_functions
+
+
+@pytest.fixture
+def server_factory() -> Callable[..., Any]:
+    """Return a factory that creates MCP servers with optional tool registration."""
+
+    def _factory(*tools: Any) -> Any:
+        server = create_server()
+        if tools:
+            register_tool_functions(server.tools, *tools)
+        return server
+
+    return _factory
+
+
+@pytest.fixture
+def context_factory() -> Callable[..., Context]:
+    """Return a factory that creates request contexts for a server."""
+
+    def _factory(
+        server: Any,
+        *,
+        request_id: str = "test",
+        method: str = "test",
+    ) -> Context:
+        return Context.create(request_id, method, server.lifespan_state)
+
+    return _factory

--- a/tests/integration/test_new_features_integration.py
+++ b/tests/integration/test_new_features_integration.py
@@ -1,32 +1,29 @@
-"""
-Integration tests for new features in v0.3.6.
-Tests how the new tools work together and with existing tools.
-"""
+"""Integration tests for the feature set introduced in v0.3.6."""
 
-import asyncio
+from __future__ import annotations
+
+import ast
 import json
-import sys
-from pathlib import Path
+from shutil import which
+from typing import Any, Dict
 
-# Add rmcp to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+import pytest
 
-from rmcp.core.server import create_server
-from rmcp.registries.tools import register_tool_functions
 from rmcp.tools.fileops import read_excel, read_json
 from rmcp.tools.formula_builder import build_formula, validate_formula
 from rmcp.tools.helpers import load_example, suggest_fix, validate_data
 from rmcp.tools.regression import correlation_analysis, linear_model
 
+pytestmark = pytest.mark.skipif(
+    which("R") is None, reason="R binary is required for integration tests"
+)
 
-async def create_integration_server():
-    """Create server with new and existing tools for integration testing."""
-    server = create_server()
 
-    # Register both new and existing tools
-    register_tool_functions(
-        server.tools,
-        # New tools
+@pytest.fixture
+def integration_server(server_factory):
+    """Return a server with the toolchain required for the new feature flows."""
+
+    return server_factory(
         build_formula,
         validate_formula,
         suggest_fix,
@@ -34,134 +31,83 @@ async def create_integration_server():
         load_example,
         read_json,
         read_excel,
-        # Existing tools
         linear_model,
         correlation_analysis,
     )
 
-    return server
 
-
-async def test_formula_to_analysis_workflow():
-    """Test complete workflow: natural language → formula → validation → analysis."""
-    print("\n🔄 Testing Formula-to-Analysis Workflow")
-    print("-" * 50)
-
-    server = await create_integration_server()
-
-    # Step 1: Build formula from natural language
-    formula_request = {
+def _tool_call_request(tool_name: str, arguments: Dict[str, Any], *, request_id: int) -> Dict[str, Any]:
+    return {
         "jsonrpc": "2.0",
-        "id": 1,
+        "id": request_id,
         "method": "tools/call",
-        "params": {
-            "name": "build_formula",
-            "arguments": {
-                "description": "predict satisfaction from purchase frequency"
-            },
-        },
+        "params": {"name": tool_name, "arguments": arguments},
     }
 
-    response = await server.handle_request(formula_request)
-    assert "result" in response
-    assert "content" in response["result"]
-    assert len(response["result"]["content"]) > 0
 
-    content_text = response["result"]["content"][0]["text"]
-    if not content_text or content_text.strip() == "":
-        raise ValueError("Empty response from formula builder")
+def _parse_result(response: Dict[str, Any]) -> Dict[str, Any]:
+    assert "result" in response, f"Response missing result payload: {response!r}"
+    result = response["result"]
+    assert not result.get("isError", False), f"Tool reported error: {result!r}"
+    content = result.get("content")
+    assert content, f"No content returned from tool: {result!r}"
 
-    formula_result = json.loads(content_text)
-    formula = formula_result["formula"]
-    print(f"   ✅ Formula built: {formula}")
+    payload = content[0]["text"]
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return ast.literal_eval(payload)
 
-    # Step 2: Load example dataset
-    data_request = {
-        "jsonrpc": "2.0",
-        "id": 2,
-        "method": "tools/call",
-        "params": {
-            "name": "load_example",
-            "arguments": {"dataset_name": "survey", "size": "small"},
-        },
-    }
 
-    response = await server.handle_request(data_request)
-    assert "result" in response
-    assert "content" in response["result"]
-    assert len(response["result"]["content"]) > 0
+async def _call_tool(server: Any, name: str, arguments: Dict[str, Any], *, request_id: int) -> Dict[str, Any]:
+    response = await server.handle_request(_tool_call_request(name, arguments, request_id=request_id))
+    return _parse_result(response)
 
-    content_text = response["result"]["content"][0]["text"]
-    if not content_text or content_text.strip() == "":
-        raise ValueError("Empty response from load_example")
 
-    data_result = json.loads(content_text)
-    dataset = data_result["data"]
-    print(f"   ✅ Dataset loaded: {data_result['metadata']['rows']} rows")
+@pytest.mark.asyncio
+async def test_formula_to_analysis_workflow(integration_server):
+    """Validate the natural-language to analysis workflow end-to-end."""
 
-    # Step 3: Validate formula against data
-    validation_request = {
-        "jsonrpc": "2.0",
-        "id": 3,
-        "method": "tools/call",
-        "params": {
-            "name": "validate_formula",
-            "arguments": {
-                "formula": "satisfaction ~ purchase_frequency",
-                "data": dataset,
-            },
-        },
-    }
-
-    response = await server.handle_request(validation_request)
-    assert "result" in response
-    assert "content" in response["result"]
-    assert len(response["result"]["content"]) > 0
-
-    content_text = response["result"]["content"][0]["text"]
-    if not content_text or content_text.strip() == "":
-        raise ValueError("Empty response from validate_formula")
-
-    validation_result = json.loads(content_text)
-    print(f"   ✅ Formula validated: {'✓' if validation_result['is_valid'] else '✗'}")
-
-    # Step 4: Run correlation analysis
-    analysis_request = {
-        "jsonrpc": "2.0",
-        "id": 4,
-        "method": "tools/call",
-        "params": {
-            "name": "correlation_analysis",
-            "arguments": {"data": dataset, "method": "pearson"},
-        },
-    }
-
-    response = await server.handle_request(analysis_request)
-    assert "result" in response
-    assert "content" in response["result"]
-    assert len(response["result"]["content"]) > 0
-
-    content_text = response["result"]["content"][0]["text"]
-    if not content_text or content_text.strip() == "":
-        raise ValueError("Empty response from correlation_analysis")
-
-    analysis_result = json.loads(content_text)
-    print(
-        f"   ✅ Analysis completed: {len(analysis_result.get('correlation_matrix', {}))} correlations"
+    formula_result = await _call_tool(
+        integration_server,
+        "build_formula",
+        {"description": "predict satisfaction from purchase frequency"},
+        request_id=1,
     )
+    formula = formula_result["formula"]
+    assert formula
 
-    return True
+    dataset_result = await _call_tool(
+        integration_server,
+        "load_example",
+        {"dataset_name": "survey", "size": "small"},
+        request_id=2,
+    )
+    dataset = dataset_result["data"]
+    assert dataset
+    assert dataset_result["metadata"]["rows"] > 0
+
+    validation_result = await _call_tool(
+        integration_server,
+        "validate_formula",
+        {"formula": "satisfaction ~ purchase_frequency", "data": dataset},
+        request_id=3,
+    )
+    assert validation_result["is_valid"]
+
+    analysis_result = await _call_tool(
+        integration_server,
+        "correlation_analysis",
+        {"data": dataset, "method": "pearson"},
+        request_id=4,
+    )
+    assert analysis_result["correlation_matrix"]
 
 
-async def test_error_recovery_workflow():
-    """Test error recovery helping with actual problems."""
-    print("\n🔧 Testing Error Recovery Workflow")
-    print("-" * 50)
-
-    server = await create_integration_server()
-
-    # Simulate common errors and test recovery suggestions
-    error_scenarios = [
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scenario",
+    [
         {
             "error": "there is no package called 'forecast'",
             "tool": "arima_model",
@@ -177,135 +123,51 @@ async def test_error_recovery_workflow():
             "tool": "correlation_analysis",
             "expected_type": "formula_syntax",
         },
-    ]
+    ],
+)
+async def test_error_recovery_workflow(integration_server, scenario: Dict[str, Any]):
+    """Ensure error diagnosis suggestions are returned for common failure modes."""
 
-    for i, scenario in enumerate(error_scenarios, 1):
-        request = {
-            "jsonrpc": "2.0",
-            "id": i,
-            "method": "tools/call",
-            "params": {
-                "name": "suggest_fix",
-                "arguments": {
-                    "error_message": scenario["error"],
-                    "tool_name": scenario["tool"],
-                },
-            },
-        }
+    result = await _call_tool(
+        integration_server,
+        "suggest_fix",
+        {
+            "error_message": scenario["error"],
+            "tool_name": scenario["tool"],
+        },
+        request_id=10,
+    )
 
-        response = await server.handle_request(request)
-        assert "result" in response
-        assert "content" in response["result"]
-        assert len(response["result"]["content"]) > 0
-
-        content_text = response["result"]["content"][0]["text"]
-        if not content_text or content_text.strip() == "":
-            raise ValueError(f"Empty response from suggest_fix for scenario {i}")
-
-        result = json.loads(content_text)
-        assert result["error_type"] == scenario["expected_type"]
-        print(f"   ✅ Error {i} diagnosed: {result['error_type']}")
-
-    return True
+    assert result["error_type"] == scenario["expected_type"]
 
 
-async def test_data_validation_integration():
-    """Test data validation with different analysis types."""
-    print("\n🔍 Testing Data Validation Integration")
-    print("-" * 50)
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dataset_name", "analysis_type"),
+    [
+        ("sales", "regression"),
+        ("customers", "classification"),
+        ("economics", "correlation"),
+    ],
+)
+async def test_data_validation_integration(
+    integration_server, dataset_name: str, analysis_type: str
+):
+    """Datasets loaded via helpers should pass validation for the requested analysis types."""
 
-    server = await create_integration_server()
+    dataset_result = await _call_tool(
+        integration_server,
+        "load_example",
+        {"dataset_name": dataset_name, "size": "small"},
+        request_id=20,
+    )
+    dataset = dataset_result["data"]
+    assert dataset
 
-    # Load different datasets and validate for different analysis types
-    datasets = ["sales", "customers", "economics"]
-    analysis_types = ["regression", "classification", "correlation"]
-
-    for dataset_name, analysis_type in zip(datasets, analysis_types):
-        # Load dataset
-        data_request = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "load_example",
-                "arguments": {"dataset_name": dataset_name, "size": "small"},
-            },
-        }
-
-        response = await server.handle_request(data_request)
-        assert "result" in response
-        assert "content" in response["result"]
-        assert len(response["result"]["content"]) > 0
-
-        content_text = response["result"]["content"][0]["text"]
-        if not content_text or content_text.strip() == "":
-            raise ValueError(f"Empty response from load_example for {dataset_name}")
-
-        data_result = json.loads(content_text)
-        dataset = data_result["data"]
-
-        # Validate for specific analysis type
-        validation_request = {
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/call",
-            "params": {
-                "name": "validate_data",
-                "arguments": {"data": dataset, "analysis_type": analysis_type},
-            },
-        }
-
-        response = await server.handle_request(validation_request)
-        assert "result" in response
-        assert "content" in response["result"]
-        assert len(response["result"]["content"]) > 0
-
-        content_text = response["result"]["content"][0]["text"]
-        if not content_text or content_text.strip() == "":
-            raise ValueError(f"Empty response from validate_data for {dataset_name}")
-
-        validation_result = json.loads(content_text)
-        print(
-            f"   ✅ {dataset_name} validated for {analysis_type}: {'✓' if validation_result['is_valid'] else '⚠'}"
-        )
-
-    return True
-
-
-async def main():
-    """Run all integration tests."""
-    print("🔗 RMCP New Features Integration Tests")
-    print("=" * 60)
-
-    tests = [
-        ("Formula-to-Analysis Workflow", test_formula_to_analysis_workflow),
-        ("Error Recovery Workflow", test_error_recovery_workflow),
-        ("Data Validation Integration", test_data_validation_integration),
-    ]
-
-    passed = 0
-    for test_name, test_func in tests:
-        print(f"\n🎯 {test_name}")
-        try:
-            success = await test_func()
-            if success:
-                passed += 1
-                print(f"✅ PASSED: {test_name}")
-            else:
-                print(f"❌ FAILED: {test_name}")
-        except Exception as e:
-            print(f"💥 ERROR: {test_name} - {e}")
-
-    print(f"\n📊 Integration Test Results: {passed}/{len(tests)} passed")
-
-    if passed == len(tests):
-        print("🎊 ALL INTEGRATION TESTS PASSED!")
-        return True
-    else:
-        print("⚠️ Some integration tests failed")
-        return False
-
-
-if __name__ == "__main__":
-    success = asyncio.run(main())
-    exit(0 if success else 1)
+    validation_result = await _call_tool(
+        integration_server,
+        "validate_data",
+        {"data": dataset, "analysis_type": analysis_type},
+        request_id=21,
+    )
+    assert "is_valid" in validation_result


### PR DESCRIPTION
## Summary
- add shared pytest fixtures for creating MCP servers and contexts
- refactor the MCP interface integration tests into parametrized pytest cases with R availability gating
- streamline the new features integration workflow tests to reuse async helpers and pytest fixtures

## Testing
- pytest tests/integration/test_mcp_interface.py tests/integration/test_new_features_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68cf50e4e244832f8731743c985b390f