### PR TITLE
Format codebase for lint compliance

### DIFF
--- a/marketing_data_example.py
+++ b/marketing_data_example.py
@@ -12,10 +12,62 @@ Usage: Copy and paste the data and questions below into Claude Desktop
 # Sample Marketing Dataset
 marketing_data = {
     "month": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-    "marketing_spend": [5000, 7500, 6000, 8000, 9500, 11000, 8500, 10000, 12000, 9000, 13500, 15000],
-    "sales_revenue": [25000, 35000, 30000, 42000, 48000, 55000, 44000, 52000, 61000, 47000, 68000, 76000],
-    "customer_satisfaction": [7.2, 7.8, 7.5, 8.1, 8.4, 8.7, 8.2, 8.5, 8.9, 8.3, 9.1, 9.3],
-    "website_traffic": [1200, 1800, 1450, 2100, 2400, 2750, 2200, 2600, 3100, 2350, 3400, 3800]
+    "marketing_spend": [
+        5000,
+        7500,
+        6000,
+        8000,
+        9500,
+        11000,
+        8500,
+        10000,
+        12000,
+        9000,
+        13500,
+        15000,
+    ],
+    "sales_revenue": [
+        25000,
+        35000,
+        30000,
+        42000,
+        48000,
+        55000,
+        44000,
+        52000,
+        61000,
+        47000,
+        68000,
+        76000,
+    ],
+    "customer_satisfaction": [
+        7.2,
+        7.8,
+        7.5,
+        8.1,
+        8.4,
+        8.7,
+        8.2,
+        8.5,
+        8.9,
+        8.3,
+        9.1,
+        9.3,
+    ],
+    "website_traffic": [
+        1200,
+        1800,
+        1450,
+        2100,
+        2400,
+        2750,
+        2200,
+        2600,
+        3100,
+        2350,
+        3400,
+        3800,
+    ],
 }
 
 print("🎯 RMCP Marketing Analysis Example")
@@ -23,10 +75,18 @@ print("=" * 50)
 
 print("\n📊 Dataset Overview:")
 print(f"• {len(marketing_data['month'])} months of data")
-print(f"• Marketing spend: ${min(marketing_data['marketing_spend']):,} - ${max(marketing_data['marketing_spend']):,}")
-print(f"• Sales revenue: ${min(marketing_data['sales_revenue']):,} - ${max(marketing_data['sales_revenue']):,}")
-print(f"• Customer satisfaction: {min(marketing_data['customer_satisfaction']):.1f} - {max(marketing_data['customer_satisfaction']):.1f}")
-print(f"• Website traffic: {min(marketing_data['website_traffic']):,} - {max(marketing_data['website_traffic']):,}")
+print(
+    f"• Marketing spend: ${min(marketing_data['marketing_spend']):,} - ${max(marketing_data['marketing_spend']):,}"
+)
+print(
+    f"• Sales revenue: ${min(marketing_data['sales_revenue']):,} - ${max(marketing_data['sales_revenue']):,}"
+)
+print(
+    f"• Customer satisfaction: {min(marketing_data['customer_satisfaction']):.1f} - {max(marketing_data['customer_satisfaction']):.1f}"
+)
+print(
+    f"• Website traffic: {min(marketing_data['website_traffic']):,} - {max(marketing_data['website_traffic']):,}"
+)
 
 print("\n" + "=" * 70)
 print("📋 COPY & PASTE THESE EXAMPLES INTO CLAUDE DESKTOP")
@@ -43,11 +103,10 @@ marketing_spend: [5000, 7500, 6000, 8000, 9500, 11000, 8500, 10000, 12000, 9000,
 sales_revenue: [25000, 35000, 30000, 42000, 48000, 55000, 44000, 52000, 61000, 47000, 68000, 76000]
 
 Please calculate ROI and show me a scatter plot with trend line.""",
-        "expected": "Linear regression showing ROI per dollar spent, R² value, scatter plot with trend line"
+        "expected": "Linear regression showing ROI per dollar spent, R² value, scatter plot with trend line",
     },
-    
     {
-        "title": "2. 🔗 Multi-Variable Correlation Analysis", 
+        "title": "2. 🔗 Multi-Variable Correlation Analysis",
         "question": """Can you analyze correlations between all these marketing variables and create a heatmap?
 
 Data:
@@ -57,9 +116,8 @@ customer_satisfaction: [7.2, 7.8, 7.5, 8.1, 8.4, 8.7, 8.2, 8.5, 8.9, 8.3, 9.1, 9
 website_traffic: [1200, 1800, 1450, 2100, 2400, 2750, 2200, 2600, 3100, 2350, 3400, 3800]
 
 Which variables are most strongly correlated?""",
-        "expected": "Correlation matrix, heatmap visualization, significance tests, insights about strongest relationships"
+        "expected": "Correlation matrix, heatmap visualization, significance tests, insights about strongest relationships",
     },
-    
     {
         "title": "3. 📊 Comprehensive Descriptive Statistics",
         "question": """Please provide comprehensive summary statistics for my marketing data:
@@ -70,9 +128,8 @@ sales_revenue: [25000, 35000, 30000, 42000, 48000, 55000, 44000, 52000, 61000, 4
 customer_satisfaction: [7.2, 7.8, 7.5, 8.1, 8.4, 8.7, 8.2, 8.5, 8.9, 8.3, 9.1, 9.3]
 
 Include outlier detection and frequency analysis.""",
-        "expected": "Mean, median, std dev, quartiles, outlier detection results, distribution analysis"
+        "expected": "Mean, median, std dev, quartiles, outlier detection results, distribution analysis",
     },
-    
     {
         "title": "4. ⏱️ Time Series Trend Analysis",
         "question": """Analyze the time series trend in my sales data and forecast next 3 months:
@@ -82,9 +139,8 @@ month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 sales_revenue: [25000, 35000, 30000, 42000, 48000, 55000, 44000, 52000, 61000, 47000, 68000, 76000]
 
 Is there a clear trend? Can you predict months 13, 14, 15?""",
-        "expected": "Time series decomposition, trend analysis, ARIMA forecasting with confidence intervals"
+        "expected": "Time series decomposition, trend analysis, ARIMA forecasting with confidence intervals",
     },
-    
     {
         "title": "5. 🎯 Marketing Effectiveness Test",
         "question": """I want to test if months with above-average marketing spend have significantly higher sales. 
@@ -94,8 +150,8 @@ marketing_spend: [5000, 7500, 6000, 8000, 9500, 11000, 8500, 10000, 12000, 9000,
 sales_revenue: [25000, 35000, 30000, 42000, 48000, 55000, 44000, 52000, 61000, 47000, 68000, 76000]
 
 Please run appropriate statistical tests.""",
-        "expected": "Two-sample t-test comparing high vs low marketing spend groups, significance tests"
-    }
+        "expected": "Two-sample t-test comparing high vs low marketing spend groups, significance tests",
+    },
 ]
 
 for i, example in enumerate(examples, 1):
@@ -113,11 +169,13 @@ print("• Start with Example 1 for basic ROI analysis")
 print("• Each example tests different RMCP capabilities")
 print("• All visualizations will appear directly in Claude chat")
 print("• Look for inline plots, statistical summaries, and insights")
-print("• Try follow-up questions like 'Create a histogram of sales' or 'Test for normality'")
+print(
+    "• Try follow-up questions like 'Create a histogram of sales' or 'Test for normality'"
+)
 
 print("\n✅ RMCP v0.3.10 Features Tested:")
 print("• Linear regression (ROI analysis)")
-print("• Correlation analysis with heatmaps") 
+print("• Correlation analysis with heatmaps")
 print("• Summary statistics and outlier detection")
 print("• Time series analysis and forecasting")
 print("• Statistical hypothesis testing")

--- a/rmcp/r_formatting.py
+++ b/rmcp/r_formatting.py
@@ -10,11 +10,11 @@ as professional markdown tables and natural language summaries.
 def get_r_formatting_utilities() -> str:
     """
     Return R code that provides common formatting functions.
-    
+
     This code will be prepended to R scripts that need formatting capabilities.
     It provides helper functions for creating markdown tables and interpreting
     statistical results in natural language.
-    
+
     Returns:
         String containing R code with formatting utilities
     """
@@ -258,11 +258,13 @@ format_model_stats <- function(model, title = "Model Statistics") {
 def get_r_formatting_for_linear_model() -> str:
     """
     Get R code specifically for formatting linear model results.
-    
+
     Returns:
         String with R code for linear model formatting
     """
-    return get_r_formatting_utilities() + """
+    return (
+        get_r_formatting_utilities()
+        + """
 
 # Format complete linear regression results
 format_linear_model_results <- function(model, formula_str, title = "Linear Regression Results") {
@@ -283,16 +285,19 @@ format_linear_model_results <- function(model, formula_str, title = "Linear Regr
     return(output)
 }
 """
+    )
 
 
 def get_r_formatting_for_correlation() -> str:
     """
     Get R code specifically for formatting correlation analysis results.
-    
+
     Returns:
         String with R code for correlation formatting
     """
-    return get_r_formatting_utilities() + """
+    return (
+        get_r_formatting_utilities()
+        + """
 
 # Format complete correlation analysis results
 format_correlation_results <- function(cor_matrix, sig_tests = NULL, method = "pearson", 
@@ -317,3 +322,4 @@ format_correlation_results <- function(cor_matrix, sig_tests = NULL, method = "p
     return(output)
 }
 """
+    )

--- a/rmcp/registries/tools.py
+++ b/rmcp/registries/tools.py
@@ -155,16 +155,16 @@ class ToolsRegistry:
                 result = {}
             elif not isinstance(result, (dict, list, str, int, float, bool)):
                 result = {"error": "Tool returned invalid result type"}
-            
+
             # Extract formatting information before validation (schema-safe approach)
             formatting_info = None
             if isinstance(result, dict) and "_formatting" in result:
                 formatting_info = result.pop("_formatting")  # Remove from result
-            
+
             # Validate output schema if provided (re-enabled for safety)
             if tool_def.output_schema:
                 validate_schema(result, tool_def.output_schema, f"tool '{name}' output")
-            
+
             await context.info(f"Tool completed: {name}")
             return self._format_tool_response(tool_def, result, formatting_info)
         except SchemaError as e:
@@ -295,21 +295,29 @@ class ToolsRegistry:
             response["structuredContent"] = structured_content
         return response
 
-    def _build_summary(self, tool_def: ToolDefinition, payload: Any, formatting_info: dict | None = None) -> str:
+    def _build_summary(
+        self,
+        tool_def: ToolDefinition,
+        payload: Any,
+        formatting_info: dict | None = None,
+    ) -> str:
         """Create a concise markdown summary for human readers."""
         title = tool_def.title or tool_def.name
-        
+
         # Check for custom formatted summary (NEW: Enhanced formatting from separate formatting_info)
         if formatting_info:
             # Priority 1: Use formatted summary if available (from R formatting utilities)
             if "summary" in formatting_info and formatting_info["summary"]:
                 # formatted_summary already includes interpretation, so just return it
                 return formatting_info["summary"]
-            
+
             # Priority 2: Use interpretation alone if no formatted_summary
-            if "interpretation" in formatting_info and formatting_info["interpretation"]:
+            if (
+                "interpretation" in formatting_info
+                and formatting_info["interpretation"]
+            ):
                 return f"## {title} Results\n\n{formatting_info['interpretation']}"
-        
+
         # Fallback to original logic for tools without custom formatting
         if isinstance(payload, str):
             return payload

--- a/rmcp/tools/regression.py
+++ b/rmcp/tools/regression.py
@@ -20,8 +20,11 @@ Example Usage:
 from typing import Any
 
 from ..core.schemas import formula_schema, table_schema
+from ..r_formatting import (
+    get_r_formatting_for_correlation,
+    get_r_formatting_for_linear_model,
+)
 from ..r_integration import execute_r_script_async
-from ..r_formatting import get_r_formatting_for_linear_model, get_r_formatting_for_correlation
 from ..registries.tools import tool
 
 
@@ -171,11 +174,13 @@ async def linear_model(context, params) -> dict[str, Any]:
         ... })
     """
     await context.info("Fitting linear regression model")
-    
+
     # Include R formatting utilities
     formatting_code = get_r_formatting_for_linear_model()
-    
-    r_script = formatting_code + """
+
+    r_script = (
+        formatting_code
+        + """
     data <- as.data.frame(args$data)
     formula <- as.formula(args$formula)
     # Handle optional parameters
@@ -224,6 +229,7 @@ async def linear_model(context, params) -> dict[str, Any]:
         )
     )
     """
+    )
     try:
         result = await execute_r_script_async(r_script, params)
         await context.info(
@@ -363,11 +369,13 @@ async def correlation_analysis(context, params) -> dict[str, Any]:
         ... })
     """
     await context.info("Computing correlation matrix")
-    
+
     # Include R formatting utilities for correlation
     formatting_code = get_r_formatting_for_correlation()
-    
-    r_script = formatting_code + """
+
+    r_script = (
+        formatting_code
+        + """
     data <- as.data.frame(args$data)
     variables <- args$variables
     method <- args$method %||% "pearson"
@@ -457,6 +465,7 @@ async def correlation_analysis(context, params) -> dict[str, Any]:
         )
     )
     """
+    )
     try:
         result = await execute_r_script_async(r_script, params)
         await context.info(

--- a/tests/unit/test_resources_registry.py
+++ b/tests/unit/test_resources_registry.py
@@ -33,9 +33,7 @@ async def test_catalog_resource_lists_registered_tools(monkeypatch):
             },
         }
 
-    monkeypatch.setattr(
-        "rmcp.tools.helpers.execute_r_script_async", fake_execute
-    )
+    monkeypatch.setattr("rmcp.tools.helpers.execute_r_script_async", fake_execute)
     context = server.create_context("res-cat", "resources/read")
     result = await server.resources.read_resource(context, "rmcp://catalog")
     markdown = result["contents"][0]["text"]
@@ -51,14 +49,10 @@ async def test_environment_resource_reports_versions(monkeypatch):
         return {
             "rVersion": "R 4.3.2",
             "platform": "x86_64-pc-linux-gnu",
-            "packages": [
-                {"name": "jsonlite", "installed": True, "version": "1.8.8"}
-            ],
+            "packages": [{"name": "jsonlite", "installed": True, "version": "1.8.8"}],
         }
 
-    monkeypatch.setattr(
-        "rmcp.registries.resources.execute_r_script_async", fake_env
-    )
+    monkeypatch.setattr("rmcp.registries.resources.execute_r_script_async", fake_env)
     server = create_server()
     context = server.create_context("res-env", "resources/read")
     result = await server.resources.read_resource(context, "rmcp://env")
@@ -95,9 +89,7 @@ async def test_dataset_resource_streams_example(monkeypatch):
             },
         }
 
-    monkeypatch.setattr(
-        "rmcp.tools.helpers.execute_r_script_async", fake_execute
-    )
+    monkeypatch.setattr("rmcp.tools.helpers.execute_r_script_async", fake_execute)
     server = create_server()
     register_tool_functions(server.tools, load_example)
     context = server.create_context("res-data", "resources/read")


### PR DESCRIPTION
## Summary
- apply Black formatting to marketing dataset example and registry tests
- tidy import ordering and multi-line expressions in formatting utilities and registries
- wrap regression R-script assembly with Black-compliant parentheses for linting

## Testing
- black --check .
- isort --check-only .
- flake8
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d07dbd5078832fbad274bae64248ca