### PR TITLE
Fix schema validation issues for Claude Code compatibility

### DIFF
--- a/rmcp/tools/flexible_r.py
+++ b/rmcp/tools/flexible_r.py
@@ -181,7 +181,7 @@ def validate_r_code(r_code: str) -> tuple[bool, Optional[str]]:
                 ),
             },
             "data": {
-                "oneOf": [table_schema(), {"type": "null"}],
+                **table_schema(),
                 "description": "Optional data to pass to R code as 'data' variable",
             },
             "packages": {

--- a/rmcp/tools/machine_learning.py
+++ b/rmcp/tools/machine_learning.py
@@ -156,44 +156,35 @@ async def kmeans_clustering(context, params) -> dict[str, Any]:
             "performance": {
                 "type": "object",
                 "description": "Model performance metrics",
-                "oneOf": [
-                    {
-                        "properties": {
-                            "accuracy": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": 1,
-                                "description": "Classification accuracy",
-                            },
-                            "confusion_matrix": {
-                                "type": "array",
-                                "items": {"type": "array", "items": {"type": "number"}},
-                                "description": "Confusion matrix for classification",
-                            },
-                        },
-                        "required": ["accuracy", "confusion_matrix"],
+                "properties": {
+                    "accuracy": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "description": "Classification accuracy (for classification trees)",
                     },
-                    {
-                        "properties": {
-                            "mse": {
-                                "type": "number",
-                                "minimum": 0,
-                                "description": "Mean squared error",
-                            },
-                            "rmse": {
-                                "type": "number",
-                                "minimum": 0,
-                                "description": "Root mean squared error",
-                            },
-                            "r_squared": {
-                                "type": "number",
-                                "maximum": 1,
-                                "description": "R-squared value",
-                            },
-                        },
-                        "required": ["mse", "rmse", "r_squared"],
+                    "confusion_matrix": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"type": "number"}},
+                        "description": "Confusion matrix (for classification trees)",
                     },
-                ],
+                    "mse": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Mean squared error (for regression trees)",
+                    },
+                    "rmse": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Root mean squared error (for regression trees)",
+                    },
+                    "r_squared": {
+                        "type": "number",
+                        "maximum": 1,
+                        "description": "R-squared value (for regression trees)",
+                    },
+                },
+                "additionalProperties": False,
             },
             "variable_importance": {
                 "type": "object",
@@ -279,53 +270,40 @@ async def decision_tree(context, params) -> dict[str, Any]:
             "performance": {
                 "type": "object",
                 "description": "Model performance metrics",
-                "oneOf": [
-                    {
-                        "properties": {
-                            "oob_error_rate": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": 1,
-                                "description": "Out-of-bag error rate",
-                            },
-                            "confusion_matrix": {
-                                "type": "array",
-                                "items": {"type": "array", "items": {"type": "number"}},
-                                "description": "Confusion matrix for classification",
-                            },
-                            "class_error": {
-                                "type": "object",
-                                "description": "Error rate by class",
-                                "additionalProperties": {"type": "number"},
-                            },
-                        },
-                        "required": [
-                            "oob_error_rate",
-                            "confusion_matrix",
-                            "class_error",
-                        ],
+                "properties": {
+                    "oob_error_rate": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 1,
+                        "description": "Out-of-bag error rate (for classification)",
                     },
-                    {
-                        "properties": {
-                            "mse": {
-                                "type": "number",
-                                "minimum": 0,
-                                "description": "Mean squared error",
-                            },
-                            "rmse": {
-                                "type": "number",
-                                "minimum": 0,
-                                "description": "Root mean squared error",
-                            },
-                            "variance_explained": {
-                                "type": "number",
-                                "description": "Percentage of variance explained",
-                                "maximum": 100,
-                            },
-                        },
-                        "required": ["mse", "rmse", "variance_explained"],
+                    "confusion_matrix": {
+                        "type": "array",
+                        "items": {"type": "array", "items": {"type": "number"}},
+                        "description": "Confusion matrix (for classification)",
                     },
-                ],
+                    "class_error": {
+                        "type": "object",
+                        "description": "Error rate by class (for classification)",
+                        "additionalProperties": {"type": "number"},
+                    },
+                    "mse": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Mean squared error (for regression)",
+                    },
+                    "rmse": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Root mean squared error (for regression)",
+                    },
+                    "variance_explained": {
+                        "type": "number",
+                        "description": "Percentage of variance explained (for regression)",
+                        "maximum": 100,
+                    },
+                },
+                "additionalProperties": False,
             },
             "variable_importance": {
                 "type": ["object", "null"],

--- a/rmcp/tools/statistical_tests.py
+++ b/rmcp/tools/statistical_tests.py
@@ -257,32 +257,30 @@ async def anova(context, params) -> dict[str, Any]:
     name="chi_square_test",
     input_schema={
         "type": "object",
-        "oneOf": [
-            {
-                "properties": {
-                    "data": table_schema(),
-                    "test_type": {"const": "independence"},
-                    "x": {"type": "string"},
-                    "y": {"type": "string"},
-                },
-                "required": ["data", "test_type", "x", "y"],
-                "additionalProperties": False,
+        "properties": {
+            "data": table_schema(),
+            "test_type": {
+                "type": "string",
+                "enum": ["independence", "goodness_of_fit"],
+                "description": "Type of chi-square test",
             },
-            {
-                "properties": {
-                    "data": table_schema(),
-                    "test_type": {"const": "goodness_of_fit"},
-                    "x": {"type": "string"},
-                    "expected": {
-                        "type": "array",
-                        "items": {"type": "number", "minimum": 0},
-                        "minItems": 1,
-                    },
-                },
-                "required": ["data", "test_type", "x"],
-                "additionalProperties": False,
+            "x": {
+                "type": "string",
+                "description": "First variable (or only variable for goodness of fit)",
             },
-        ],
+            "y": {
+                "type": "string",
+                "description": "Second variable (required for independence test)",
+            },
+            "expected": {
+                "type": "array",
+                "items": {"type": "number", "minimum": 0},
+                "minItems": 1,
+                "description": "Expected frequencies (for goodness of fit test)",
+            },
+        },
+        "required": ["data", "test_type", "x"],
+        "additionalProperties": False,
     },
     output_schema={
         "type": "object",


### PR DESCRIPTION
- Remove oneOf/allOf/anyOf from top-level tool schemas
- Flatten decision_tree and random_forest performance schemas
- Flatten chi_square_test input schema
- Fix flexible_r data schema
- Ensure compatibility with Claude's API requirements

All 44 tools now work without schema validation errors.