### PR TITLE
Handle MCP protocol negotiation for supported versions

### DIFF
--- a/rmcp/core/server.py
+++ b/rmcp/core/server.py
@@ -44,6 +44,11 @@ except Exception:  # pragma: no cover - optional dependency
         "alert",
         "emergency",
     ]
+# Supported MCP protocol versions (latest first)
+_SUPPORTED_PROTOCOL_VERSIONS = tuple(
+    dict.fromkeys((_PROTOCOL_VERSION, "2025-06-18"))
+)
+
 # Import version from __init__ at runtime to avoid circular imports
 from ..registries.prompts import PromptsRegistry
 from ..registries.resources import ResourcesRegistry
@@ -463,6 +468,15 @@ All tools provide professionally formatted output with markdown tables, statisti
         Returns:
             Initialize response with server capabilities
         """
+        requested_version = params.get("protocolVersion")
+        if requested_version and requested_version not in _SUPPORTED_PROTOCOL_VERSIONS:
+            raise ValueError(
+                "Unsupported protocol version requested: "
+                f"{requested_version}. Supported versions: "
+                f"{', '.join(_SUPPORTED_PROTOCOL_VERSIONS)}"
+            )
+        protocol_version = requested_version or _PROTOCOL_VERSION
+
         client_info = params.get("clientInfo", {})
         logger.info(
             f"Initializing MCP connection with client: "
@@ -477,7 +491,7 @@ All tools provide professionally formatted output with markdown tables, statisti
                 logging=LoggingCapability(),
             )
             initialize_result = InitializeResult(
-                protocolVersion=_PROTOCOL_VERSION,
+                protocolVersion=protocol_version,
                 capabilities=capabilities,
                 serverInfo=Implementation(name=self.name, version=self.version),
                 instructions=self.description or None,
@@ -492,7 +506,7 @@ All tools provide professionally formatted output with markdown tables, statisti
             "completion": {},
         }
         result = {
-            "protocolVersion": _PROTOCOL_VERSION,
+            "protocolVersion": protocol_version,
             "capabilities": capabilities_dict,
             "serverInfo": {"name": self.name, "version": self.version},
         }


### PR DESCRIPTION
## Summary
- validate and reuse the supported MCP protocol versions and echo the client request during initialize
- default initialize params to the requested protocol version from the HTTP header when missing
- share the negotiated protocol list between the server and HTTP transport validation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b5359d12c832fbe6542aef54677e6)