### PR TITLE
Align the release process with py-canon: tag-as-version, tags-only publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,40 +1,99 @@
 name: Publish to PyPI
 
+# Tag-driven only. There is deliberately no workflow_dispatch: a manual
+# trigger publishes whatever is on the runner, with no gate. Every release
+# before 0.10.0 shipped that way. Releases now come from a v* tag, which
+# comes from main, which CI gates.
+#
+# The filename is load-bearing: the PyPI trusted publisher is keyed to
+# python-publish.yml. See py-canon STANDARD.md "Legacy publishers" -- keeping
+# the legacy name means no pypi.org change is needed. py-canon normally splits
+# build/release into a reusable workflow and leaves only publish here, but that
+# needs cross-workflow artifact passing, so all three jobs are inlined instead.
+
 on:
   push:
-    tags:
-      - 'v*'
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      reason:
-        description: 'Likely Test'
-        required: false
-        default: 'Manual build'
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write  # required for trusted publishing
-
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          python-version: '3.11'
+          fetch-depth: 0 # uv-dynamic-versioning derives the version from tags
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
-        with:
-          enable-cache: true
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
-      - name: Build package
+      - name: Build distributions
+        run: uv build
+
+      - name: Check metadata
+        run: uvx twine check dist/*
+
+      # Cheap guard against a shallow clone or missing tags yielding 0.0.0,
+      # which would otherwise publish a bogus version under a good tag.
+      - name: Confirm the built version matches the tag
         run: |
-          uv build
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ ${#wheels[@]} -ne 1 ]; then
+            echo "::error::expected exactly one wheel, found ${#wheels[@]}"
+            exit 1
+          fi
+          name="${wheels[0]##*/}"
+          built="${name#rmcp-}"
+          built="${built%-py3-none-any.whl}"
+          expected="${GITHUB_REF_NAME#v}"
+          echo "tag=$expected built=$built"
+          if [ "$built" != "$expected" ]; then
+            echo "::error::Built version $built does not match tag $expected"
+            exit 1
+          fi
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: pypi
+    permissions:
+      id-token: write # trusted publishing + attestations
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish (trusted publishing, PEP 740 attestations)
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        with:
+          attestations: true
+
+  github-release:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY" --generate-notes --verify-tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,6 +551,32 @@ cd docs/_build/html && python -m http.server 8080
 
 **📖 Documentation URL**: `docs/_build/html/index.html` (after building)
 
+## Releasing
+
+**The git tag is the version.** `uv-dynamic-versioning` derives it from the
+latest `v*` tag, so there is nothing to bump — `pyproject.toml` carries no
+version number and editing one in is a mistake.
+
+```bash
+# after the change is merged to main and CI is green
+git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z
+```
+
+The tag push runs `.github/workflows/python-publish.yml`: build →
+`twine check` → tag/version match guard → PyPI (trusted publishing, PEP 740
+attestations) → GitHub Release with generated notes.
+
+There is **no manual trigger, deliberately**. A `workflow_dispatch` publishes
+whatever is on the runner with nothing gating it, which is how every release
+before 0.10.0 shipped. Tags come from `main`, and `main` is CI-gated — that is
+the gate. Note the corollary: a tag placed on a commit that never passed CI
+would still publish, so tag from `main`, and use the `pypi` environment's
+protection rules if you want a hard stop.
+
+The filename `python-publish.yml` is load-bearing — the PyPI trusted publisher
+is keyed to it. Renaming it breaks publishing until the publisher config is
+updated on pypi.org. See py-canon `STANDARD.md` "Legacy publishers".
+
 ## Important Notes
 - Python 3.11+ required
 - R environment provided via Docker (no local R installation needed for development)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "rmcp"
-version = "0.10.0"
+# The git tag is the version -- derived from the latest v* tag by
+# uv-dynamic-versioning. No bump commits, no version edits.
+dynamic = ["version"]
 description = "Model Context Protocol server bringing R statistical analysis to Claude Desktop and Claude web, over stdio and Streamable HTTP"
 authors = [{name = "Gaurav Sood", email = "gsood07@gmail.com"}]
 license = {text = "MIT"}
@@ -85,12 +87,27 @@ Documentation = "https://github.com/finite-sample/rmcp#readme"
 Issues = "https://github.com/finite-sample/rmcp/issues"
 
 [build-system]
-requires = ["uv_build"]
-build-backend = "uv_build"
+requires = ["hatchling>=1.27", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
 
-# uv build backend configuration
-[tool.uv.build-backend]
-module-root = "."
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+
+# Flat layout: the package lives at the repo root, not under src/.
+[tool.hatch.build.targets.wheel]
+packages = ["rmcp"]
+
+[tool.hatch.build.targets.sdist]
+include = ["rmcp", "README.md", "LICENSE", "CHANGELOG.md"]
+
+# uv_build packaged from the working directory, so local Finder metadata
+# could reach a distribution. Keep it out explicitly.
+[tool.hatch.build]
+exclude = ["**/.DS_Store"]
 
 # Tool configurations
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,12 @@ source = "uv-dynamic-versioning"
 [tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"
+# The Docker build copies only pyproject.toml and rmcp/ (.dockerignore
+# excludes .git), so there is no repository to read a tag from. Without a
+# fallback the backend raises "This does not appear to be a Git project" and
+# the image build fails. Release builds run in a full checkout and derive the
+# real version from the tag; the publish workflow asserts that it matches.
+fallback-version = "0.0.0"
 
 # Flat layout: the package lives at the repo root, not under src/.
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -1384,7 +1384,6 @@ wheels = [
 
 [[package]]
 name = "rmcp"
-version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1444,7 +1443,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=23.1.0" },
     { name = "uvicorn", specifier = ">=0.31.1" },
 ]
-provides-extras = ["http", "all"]
+provides-extras = ["all", "http"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes the gap flagged after 0.10.0: `python-publish.yml` accepted `workflow_dispatch`, had no `needs:`, and `ci.yml` doesn't trigger on tags — so a manual dispatch could publish untested code. That's how every release before 0.10.0 shipped. 0.10.0 was safe only because a PR happened to gate it.

## What consulting `../preen` changed

My original framing was "add a test gate to the publish workflow." That's wrong. **py-canon's `reusable-release.yml` doesn't run tests either** — it's build → `twine check` → publish → GitHub Release. The canon's control is structural: `workflow_dispatch` appears **nowhere** in its CI or release workflows, only in `fleet-health.yml`. Releases fire from tags only, so untested code can't be hand-published in the first place. Deleting that trigger *is* the fix.

The canon also goes further — STANDARD.md:60: **"The git tag is the version."**

## Changes

**Tag-as-version.** `uv-dynamic-versioning` + hatchling, replacing the static `version = "0.10.0"` (hand-edited yesterday — exactly the drift this removes) and the `uv_build` backend. `rmcp/version.py` already read `importlib.metadata`, so only the source of truth moved.

**Tags-only publishing**, restructured after py-canon job-for-job: `build` (fetch-depth 0, `uv build`, `twine check`) → `publish` (`environment: pypi`, PEP 740 attestations) → `github-release` (`--generate-notes --verify-tag`). Every action pinned to py-canon's SHAs. Also drops `release: [published]`, which would now be recursive since this workflow creates releases.

**One guard the canon doesn't need:** the build asserts the built version matches the tag, catching a shallow clone or missing tags yielding `0.0.0` under a good tag. rmcp only just moved to tag-derived versions.

## Verification

The backend swap was the risk, so I verified the artifact rather than the build. The new wheel's file set is **identical** to the published 0.10.0 — 58 R scripts, `py.typed`, `DESCRIPTION`/`NAMESPACE`, 46 modules, zero additions or removals.

Version derivation: at the tag → `0.10.0`; one commit past → `0.10.0.post1.dev0+a8c3750`. `twine check` passes both artifacts. actionlint clean. 279 tests passing.

Incidental find: `uv_build` packaged from the working directory rather than VCS, so a local `uv build` swept in gitignored `.DS_Store` files. Published artifacts are clean because CI builds from a fresh checkout (verified against the installed 0.10.0), but the old dispatch path built from whatever was on the runner. Excluded explicitly now.

## Deliberately not doing

- **No CI-on-tags** — the canon doesn't, and it re-runs what already passed on main. The real control is tags-only plus the `pypi` environment's protection rules.
- **Not adopting `reusable-ci.yml`** — it's generic Python; rmcp's CI is R/Docker-centric and swapping it in would drop the R integration coverage the Docker-tag fix just restored.

## Needs a repo-settings action

The `pypi` environment should exist with deployments restricted to `v*` tags (optionally required reviewers). Without it the job still runs; the environment just adds no protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)