### PR TITLE
Make structured logging actually structured; document shell completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,19 @@ uv run rmcp serve-http           # Start Streamable HTTP server
 uv run rmcp --debug start        # Enable debug mode
 uv run rmcp --config config.json start  # Use custom config file
 RMCP_LOG_LEVEL=DEBUG uv run rmcp start  # Use environment variables
+
+# Shell completion (click provides it; zsh/bash/fish all verified)
+eval "$(_RMCP_COMPLETE=zsh_source rmcp)"   # bash needs 4.4+, macOS ships 3.2
+```
+
+Logs go to **stderr** as one JSON object per line — stdout carries the JSON-RPC
+stream in stdio mode. Every record, whether from structlog or plain `logging`,
+gets the same envelope, and anything logged while serving a request carries
+`request_id`, so a tool call and its R execution can be tied together:
+
+```json
+{"event": "tool completed", "tool": "linear_model", "duration_ms": 412,
+ "ok": true, "request_id": "7", "component": "registries.tools", ...}
 ```
 
 **For R integration development (Docker-based):**

--- a/README.md
+++ b/README.md
@@ -189,6 +189,22 @@ rmcp --debug start
 rmcp --version
 ```
 
+### Shell Completion
+
+```bash
+# zsh — add to ~/.zshrc
+eval "$(_RMCP_COMPLETE=zsh_source rmcp)"
+
+# bash — add to ~/.bashrc (requires bash 4.4+)
+eval "$(_RMCP_COMPLETE=bash_source rmcp)"
+
+# fish — write to the completions directory
+_RMCP_COMPLETE=fish_source rmcp > ~/.config/fish/completions/rmcp.fish
+```
+
+macOS ships bash 3.2, which is too old — click prints a warning and completion
+does nothing. Use zsh (the macOS default) or install a newer bash.
+
 ### ⚙️ Configuration
 
 RMCP supports flexible configuration through environment variables, configuration files, and command-line options:

--- a/rmcp/core/sdk_adapter.py
+++ b/rmcp/core/sdk_adapter.py
@@ -23,6 +23,7 @@ from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.models import InitializationOptions
 from pydantic import AnyUrl
 
+from ..logging_config import set_request_id
 from .context import Context
 
 if TYPE_CHECKING:
@@ -102,6 +103,11 @@ class SDKServerAdapter:
                 progress_token = rc.meta.progressToken
         except LookupError:
             pass
+
+        # Publish it so every line logged while serving this request carries it.
+        # asyncio copies the context into child tasks, so the R execution under
+        # a tool call is correlatable with the call itself.
+        set_request_id(request_id)
 
         async def progress_callback(message: str, current: int, total: int) -> None:
             if session is None or progress_token is None:

--- a/rmcp/logging_config.py
+++ b/rmcp/logging_config.py
@@ -1,69 +1,46 @@
 """
 Structured logging configuration for RMCP MCP Server.
 
-Provides JSON-formatted structured logging optimized for:
-- MCP protocol observability and debugging
-- Request correlation across tool chains and R execution
-- Integration with modern monitoring platforms (ELK, Grafana, Datadog)
-- Performance monitoring of statistical workflows
+Every record -- whether emitted through structlog or through plain ``logging``
+-- is rendered once, by a single ``ProcessorFormatter``, into one envelope:
 
-Key Features:
-- Correlation ID propagation through context vars
-- MCP-specific structured fields (tool_name, session_id, execution_time)
-- Security event logging (operation approval, VFS access)
-- Development vs production logging modes
+    {"event": ..., "level": ..., "component": ..., "timestamp": ...,
+     "service": "rmcp", "protocol": "mcp", "request_id": ...}
+
+Fields stay top-level and therefore queryable. Anything logged while serving a
+request also carries ``request_id``, which is what ties a tool call to the R
+execution underneath it.
+
+Output goes to stderr: stdout carries the JSON-RPC stream in stdio mode and
+must not be written to.
 """
 
 import contextvars
-import json
 import logging
 import logging.config
 import sys
-import time
 import uuid
 from pathlib import Path
 from typing import Any
 
 import structlog
 
-# Context variables for request correlation
-correlation_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "correlation_id", default=None
-)
-session_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "session_id", default=None
-)
+#: Set once per request by ``SDKServerAdapter._create_context``. asyncio copies
+#: the context when a task is created, so every line logged while serving a
+#: request carries the id -- which is what makes a tool call and its R
+#: execution correlatable.
 request_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "request_id", default=None
-)
-
-# Performance tracking
-request_start_time_var: contextvars.ContextVar[float | None] = contextvars.ContextVar(
-    "request_start_time", default=None
 )
 
 
 def add_correlation_context(
     logger: structlog.BoundLogger, method_name: str, event_dict: dict[str, Any]
 ) -> dict[str, Any]:
-    """Add correlation IDs and request context to all log entries."""
-    # Add correlation identifiers
-    correlation_id = correlation_id_var.get()
-    if correlation_id:
-        event_dict["correlation_id"] = correlation_id
-
-    session_id = session_id_var.get()
-    if session_id:
-        event_dict["session_id"] = session_id
-
+    """Attach the current request id, when one is in scope."""
     request_id = request_id_var.get()
     if request_id:
         event_dict["request_id"] = request_id
-
-    # Add execution timing if available
-    start_time = request_start_time_var.get()
-    if start_time:
-        event_dict["execution_time_ms"] = int((time.time() - start_time) * 1000)
 
     return event_dict
 
@@ -72,22 +49,12 @@ def add_mcp_context(
     logger: structlog.BoundLogger, method_name: str, event_dict: dict[str, Any]
 ) -> dict[str, Any]:
     """Add MCP-specific context fields."""
-    # Ensure component field is set
     if "component" not in event_dict:
-        # Try to get logger name from the underlying logger
-        if hasattr(logger, "_logger") and hasattr(logger._logger, "name"):
-            logger_name = logger._logger.name
-        elif hasattr(logger, "name"):
-            logger_name = logger.name
-        else:
-            logger_name = "unknown"
+        # structlog.stdlib.add_logger_name runs first and sets this for both
+        # structlog-native and plain-stdlib records.
+        logger_name = event_dict.get("logger") or "unknown"
+        event_dict["component"] = logger_name.removeprefix("rmcp.")
 
-        if "rmcp." in logger_name:
-            event_dict["component"] = logger_name.replace("rmcp.", "")
-        else:
-            event_dict["component"] = logger_name
-
-    # Add service identification
     event_dict["service"] = "rmcp"
     event_dict["protocol"] = "mcp"
 
@@ -112,74 +79,53 @@ def configure_structured_logging(
     # Clear existing configuration
     structlog.reset_defaults()
 
-    # Shared processors for all loggers
+    # Applied to structlog-native records and, via foreign_pre_chain below, to
+    # records from the modules that still use plain `logging` -- so both end up
+    # with the same envelope instead of two incompatible shapes.
+    #
+    # filter_by_level is deliberately absent: it needs a structlog logger and
+    # would fail on foreign records. It goes in the structlog chain only, and
+    # first, so dropped events skip the work below.
     shared_processors = [
-        # Add correlation and MCP context
+        structlog.stdlib.add_logger_name,
         add_correlation_context,
         add_mcp_context,
-        # Filter for log level
-        structlog.stdlib.filter_by_level,
-        # Add timestamp
         structlog.processors.TimeStamper(fmt="ISO", utc=True),
-        # Add stack info for errors
-        structlog.dev.set_exc_info,
         structlog.processors.add_log_level,
+        structlog.dev.set_exc_info,
     ]
 
-    if development_mode and enable_console:
-        # Pretty console output for development
-        processors = shared_processors + [structlog.dev.ConsoleRenderer(colors=True)]
-        formatter = None
-    else:
-        # JSON output for production
-        processors = shared_processors + [
-            structlog.processors.dict_tracebacks,
-            structlog.processors.JSONRenderer(),
-        ]
-
-        class JSONFormatter(logging.Formatter):
-            """Custom JSON formatter for standard library logging."""
-
-            def format(self, record: logging.LogRecord) -> str:
-                log_entry = {
-                    "timestamp": self.formatTime(record),
-                    "level": record.levelname,
-                    "component": record.name.replace("rmcp.", "")
-                    if "rmcp." in record.name
-                    else record.name,
-                    "message": record.getMessage(),
-                    "service": "rmcp",
-                    "protocol": "mcp",
-                }
-
-                # Add correlation context if available
-                correlation_id = correlation_id_var.get()
-                if correlation_id:
-                    log_entry["correlation_id"] = correlation_id
-
-                session_id = session_id_var.get()
-                if session_id:
-                    log_entry["session_id"] = session_id
-
-                request_id = request_id_var.get()
-                if request_id:
-                    log_entry["request_id"] = request_id
-
-                # Add exception info if present
-                if record.exc_info:
-                    log_entry["exception"] = self.formatException(record.exc_info)
-
-                return json.dumps(log_entry, default=str)
-
-        formatter = JSONFormatter()
-
-    # Configure structlog
+    # structlog hands the event dict to the stdlib handler rather than
+    # rendering it itself. Rendering happens once, in the formatter below.
+    # Previously structlog rendered JSON and a second formatter nested that
+    # string under "message", so no field was ever queryable.
     structlog.configure(
-        processors=processors,
+        processors=[
+            structlog.stdlib.filter_by_level,
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
         wrapper_class=structlog.stdlib.BoundLogger,
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         cache_logger_on_first_use=True,
+    )
+
+    if development_mode and enable_console:
+        renderer: Any = structlog.dev.ConsoleRenderer(colors=True)
+        render_chain = [renderer]
+    else:
+        renderer = structlog.processors.JSONRenderer()
+        render_chain = [structlog.processors.dict_tracebacks, renderer]
+
+    # foreign_pre_chain is what gives records from the plain-`logging` modules
+    # the same envelope as structlog ones, without touching those modules.
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared_processors,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            *render_chain,
+        ],
     )
 
     # Configure standard library logging
@@ -187,14 +133,12 @@ def configure_structured_logging(
 
     if enable_console:
         console_handler = logging.StreamHandler(sys.stderr)
-        if formatter:
-            console_handler.setFormatter(formatter)
+        console_handler.setFormatter(formatter)
         handlers.append(console_handler)
 
     if log_file:
         file_handler = logging.FileHandler(log_file)
-        if formatter:
-            file_handler.setFormatter(formatter)
+        file_handler.setFormatter(formatter)
         handlers.append(file_handler)
 
     logging.basicConfig(
@@ -212,90 +156,12 @@ def get_logger(name: str) -> structlog.BoundLogger:
     return structlog.get_logger(name)
 
 
-def set_correlation_id(correlation_id: str | None = None) -> str:
-    """Set correlation ID for request tracking. Returns the set ID."""
-    if correlation_id is None:
-        correlation_id = str(uuid.uuid4())
-    correlation_id_var.set(correlation_id)
-    return correlation_id
-
-
-def set_session_id(session_id: str | None = None) -> str:
-    """Set session ID for multi-request workflows. Returns the set ID."""
-    if session_id is None:
-        session_id = str(uuid.uuid4())
-    session_id_var.set(session_id)
-    return session_id
-
-
 def set_request_id(request_id: str | None = None) -> str:
     """Set request ID for individual operations. Returns the set ID."""
     if request_id is None:
         request_id = str(uuid.uuid4())
     request_id_var.set(request_id)
     return request_id
-
-
-def start_request_timing() -> None:
-    """Start timing for current request."""
-    request_start_time_var.set(time.time())
-
-
-def get_execution_time_ms() -> int | None:
-    """Get execution time in milliseconds if timing was started."""
-    start_time = request_start_time_var.get()
-    if start_time:
-        return int((time.time() - start_time) * 1000)
-    return None
-
-
-class LogContext:
-    """Context manager for scoped logging context."""
-
-    def __init__(
-        self,
-        correlation_id: str | None = None,
-        session_id: str | None = None,
-        request_id: str | None = None,
-        start_timing: bool = True,
-    ):
-        self.correlation_id = correlation_id
-        self.session_id = session_id
-        self.request_id = request_id
-        self.start_timing = start_timing
-        self._tokens = []
-
-    def __enter__(self):
-        """Enter logging context and set context variables."""
-        if self.correlation_id:
-            token = correlation_id_var.set(self.correlation_id)
-            self._tokens.append(("correlation_id", token))
-
-        if self.session_id:
-            token = session_id_var.set(self.session_id)
-            self._tokens.append(("session_id", token))
-
-        if self.request_id:
-            token = request_id_var.set(self.request_id)
-            self._tokens.append(("request_id", token))
-
-        if self.start_timing:
-            token = request_start_time_var.set(time.time())
-            self._tokens.append(("start_time", token))
-
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Exit logging context and reset context variables."""
-        for var_name, token in reversed(self._tokens):
-            if var_name == "correlation_id":
-                correlation_id_var.set(token.old_value)
-            elif var_name == "session_id":
-                session_id_var.set(token.old_value)
-            elif var_name == "request_id":
-                request_id_var.set(token.old_value)
-            elif var_name == "start_time":
-                request_start_time_var.set(token.old_value)
 
 
 def log_tool_execution(
@@ -388,34 +254,3 @@ def log_r_execution(
         if error_message:
             log_data["error_message"] = error_message
         logger.error("R execution failed", **log_data)
-
-
-def log_http_request(
-    logger: structlog.BoundLogger,
-    method: str,
-    path: str,
-    status_code: int,
-    response_time_ms: int,
-    user_agent: str | None = None,
-    content_length: int | None = None,
-) -> None:
-    """Log HTTP transport requests."""
-    log_data = {
-        "method": method,
-        "path": path,
-        "status_code": status_code,
-        "response_time_ms": response_time_ms,
-    }
-
-    if user_agent:
-        log_data["user_agent"] = user_agent
-
-    if content_length is not None:
-        log_data["content_length"] = content_length
-
-    if 200 <= status_code < 400:
-        logger.info("HTTP request processed", **log_data)
-    elif 400 <= status_code < 500:
-        logger.warning("HTTP client error", **log_data)
-    else:
-        logger.error("HTTP server error", **log_data)

--- a/rmcp/registries/tools.py
+++ b/rmcp/registries/tools.py
@@ -10,7 +10,7 @@ Following the principle: "Registries are discoverable and testable."
 
 import inspect
 import json
-import logging
+import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Sequence
@@ -19,8 +19,16 @@ from typing import Any, Protocol
 
 from ..core.context import Context
 from ..core.schemas import SchemaError, validate_schema
+from ..logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+# structlog rather than stdlib: this module logs keyword fields (tool,
+# duration_ms) that stdlib logging would drop.
+logger = get_logger(__name__)
+
+
+def _elapsed_ms(started: float) -> int:
+    """Milliseconds since a ``time.perf_counter()`` reading."""
+    return int((time.perf_counter() - started) * 1000)
 
 
 class ToolHandler(Protocol):
@@ -163,6 +171,7 @@ class ToolsRegistry:
         if name not in self._tools:
             raise ValueError(f"Unknown tool: {name}")
         tool_def = self._tools[name]
+        started = time.perf_counter()
         try:
             # Validate input schema
             validate_schema(
@@ -191,14 +200,36 @@ class ToolsRegistry:
                 validate_schema(result, tool_def.output_schema, f"tool '{name}' output")
 
             await context.info(f"Tool completed: {name}")
+            # Deliberately name + timing only. context.info above already ships
+            # the raw arguments to the client; don't copy payloads into logs.
+            logger.info(
+                "tool completed",
+                tool=name,
+                duration_ms=_elapsed_ms(started),
+                ok=True,
+            )
             return self._format_tool_response(tool_def, result, formatting_info)
         except SchemaError as e:
             await context.error(f"Schema validation failed for tool '{name}': {e}")
+            logger.warning(
+                "tool rejected",
+                tool=name,
+                duration_ms=_elapsed_ms(started),
+                ok=False,
+                reason="schema",
+            )
             return {
                 "content": [{"type": "text", "text": f"Error: {e}"}],
                 "isError": True,
             }
         except Exception as e:
+            # exception() keeps the traceback, which the isError result drops.
+            logger.exception(
+                "tool failed",
+                tool=name,
+                duration_ms=_elapsed_ms(started),
+                ok=False,
+            )
             await context.error(f"Tool execution failed for '{name}': {e}")
             return {
                 "content": [{"type": "text", "text": f"Tool execution error: {e}"}],

--- a/tests/unit/core/test_logging_shape.py
+++ b/tests/unit/core/test_logging_shape.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""The shape of emitted log lines.
+
+Regression cover for a configuration where structlog rendered JSON and a second
+formatter nested that string under ``message``, so every structured field was
+trapped inside an escaped string and nothing was queryable. Shape is asserted
+rather than eyeballed because that failure looks fine at a glance.
+"""
+
+import contextlib
+import io
+import json
+import logging
+
+import pytest
+from rmcp.logging_config import (
+    configure_structured_logging,
+    get_logger,
+    request_id_var,
+    set_request_id,
+)
+
+
+def _emit(fn, **kwargs) -> list[dict]:
+    """Run `fn`, returning the JSON log lines it produced on stderr."""
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        configure_structured_logging(level="INFO", **kwargs)
+        fn()
+    return [json.loads(line) for line in buf.getvalue().strip().splitlines() if line]
+
+
+@pytest.fixture(autouse=True)
+def _reset_request_id():
+    token = request_id_var.set(None)
+    yield
+    request_id_var.reset(token)
+
+
+class TestSingleEncoding:
+    def test_fields_are_top_level_not_nested_in_a_string(self):
+        """The regression: fields must not be buried in an escaped JSON string."""
+        lines = _emit(
+            lambda: get_logger("rmcp.demo").info(
+                "tool completed", tool="linear_model", duration_ms=42
+            )
+        )
+        assert len(lines) == 1
+        entry = lines[0]
+
+        assert entry["tool"] == "linear_model"
+        assert entry["duration_ms"] == 42
+        assert entry["event"] == "tool completed"
+
+    def test_no_field_value_is_itself_json(self):
+        """A double-encoded line hides a whole JSON object inside one value."""
+        lines = _emit(
+            lambda: get_logger("rmcp.demo").info("hello", tool="x", duration_ms=1)
+        )
+        for value in lines[0].values():
+            if isinstance(value, str) and value.startswith("{"):
+                with pytest.raises(json.JSONDecodeError):
+                    json.loads(value)
+
+
+class TestOneShape:
+    def test_structlog_and_stdlib_share_an_envelope(self):
+        """The 10 modules on plain `logging` must not emit a second shape."""
+
+        def emit_both():
+            get_logger("rmcp.demo").info("from structlog")
+            logging.getLogger("rmcp.core.server").info("from stdlib")
+
+        lines = _emit(emit_both)
+        assert len(lines) == 2
+        envelope = {"event", "level", "component", "timestamp", "service", "protocol"}
+        for entry in lines:
+            assert envelope <= set(entry), f"missing {envelope - set(entry)}"
+
+    def test_component_strips_the_package_prefix(self):
+        lines = _emit(lambda: logging.getLogger("rmcp.core.server").info("x"))
+        assert lines[0]["component"] == "core.server"
+
+
+class TestRequestIdPropagation:
+    def test_absent_when_no_request_is_in_scope(self):
+        lines = _emit(lambda: get_logger("rmcp.demo").info("no request"))
+        assert "request_id" not in lines[0]
+
+    def test_present_on_every_line_once_set(self):
+        """This is what ties a tool call to the R execution beneath it."""
+
+        def emit():
+            set_request_id("req-42")
+            get_logger("rmcp.demo").info("structlog line")
+            logging.getLogger("rmcp.core.server").info("stdlib line")
+
+        lines = _emit(emit)
+        assert [entry.get("request_id") for entry in lines] == ["req-42", "req-42"]
+
+
+class TestStdoutIsNeverWritten:
+    def test_output_goes_to_stderr(self):
+        """stdout carries the JSON-RPC stream in stdio mode."""
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            configure_structured_logging(level="INFO")
+            get_logger("rmcp.demo").info("should not reach stdout")
+
+        assert out.getvalue() == ""
+        assert "should not reach stdout" in err.getvalue()


### PR DESCRIPTION
Answers "do we do structured logging?" — in name yes, in practice no.

## Double encoding

structlog rendered to a JSON *string*, then a hand-rolled `JSONFormatter` put that string into a `message` field:

```json
{"timestamp": "...", "level": "INFO", "component": "r_integration",
 "message": "{\"execution_time_ms\": 1234, \"success\": true, \"event\": \"R execution completed\"}"}
```

Every structured field was trapped inside an escaped string, so Cloud Logging indexed `message` as opaque text — JSON logs you cannot query by field. Lines also carried two timestamps and two levels.

Replaced with `structlog.stdlib.ProcessorFormatter`, which renders once. After:

```json
{"event": "tool completed", "tool": "linear_model", "duration_ms": 412, "ok": true,
 "request_id": "7", "component": "registries.tools", "level": "info", "service": "rmcp"}
```

## Two shapes in one stream

Only 4 modules used structlog; 10 used plain `logging` and emitted no fields at all. `ProcessorFormatter`'s `foreign_pre_chain` gives those the same envelope without touching them. Verified on a live stdio run: **20/20 and 16/16 stderr lines structured**, previously a mix.

## A dead correlation subsystem

`set_correlation_id`, `set_session_id`, `start_request_timing`, `get_execution_time_ms`, `LogContext`, `log_http_request` — zero callers, and the contextvars were never set, so `add_correlation_context` was a no-op on every line.

Deleted, **except `request_id`** — which `sdk_adapter._create_context` already computed and simply never published. Publishing it means a tool call and the R execution beneath it now share an id, which is the entire point of the subsystem.

`session_id` is deliberately not wired: `rc.session` is a session *object*, not the `Mcp-Session-Id` string. A faked field is worse than an absent one.

**421 → 255 lines.**

## Tool calls were invisible

`context.info` goes to the *MCP client*, not to logs, so an operator saw startup banners and then silence — no tool name, no duration, no outcome, and exceptions swallowed into the `isError` result with the traceback lost.

`call_tool` is now timed and logs name/duration/outcome, with `logger.exception` on failure. Arguments are deliberately **not** logged — `context.info` already ships those to the client, and payloads don't belong in logs.

## Tests

There were none for any of this. Seven added, asserting *shape* rather than eyeballing output. **Three fail against the old configuration** — that is the point: double encoding looks fine at a glance and would regress silently.

286 passing (was 279). stdout verified pure JSON-RPC on both `rmcp start` and `rmcp serve`.

## Shell completion

Documentation only. click has always provided it; nothing mentioned it. zsh, bash and fish all verified — bash needs 4.4+ and macOS ships 3.2, so that caveat is stated rather than left to bite. No framework change: `py-canon/STANDARD.md` mandates no CLI framework, so preen's typer+rich is its own choice, not a conformance gap.

## Found while testing, not fixed here

The new tool logging immediately surfaced a real pre-existing bug: `validate_data` returns `warnings`/`errors`/`suggestions` as bare strings when R produces exactly one, but the schema requires arrays — `toJSON(auto_unbox=TRUE)` collapses length-1 vectors. `validate_data.R:195-197` guards the empty case but not length-1, so the tool fails on any small dataset that triggers exactly one suggestion. The codebase already has the idiom for this (`I()` in `read_csv.R`). Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)