### PR TITLE
Port the SDK adapter to mcp 2.x, drop the <2 cap (closes #52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,7 +474,7 @@ jobs:
                         "summary_stats",
                         {"data": {"x": [1, 2, 3, 4, 5]}, "variables": ["x"]},
                     )
-                    assert not result.isError, result.content
+                    assert not result.is_error, result.content
                     print(f"MCP stdio OK: {len(names)} tools, summary_stats ran")
 
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -106,7 +106,7 @@ async def main():
                     "data": {"y": [2.0, 4.1, 6.2], "x": [1, 2, 3]},
                 },
             )
-            print(result.structuredContent)
+            print(result.structured_content)
 ```
 
 ### Claude API (MCP connector)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,7 @@ requires-python = ">=3.11"
 dependencies = [
     "click>=8.1.0",        # CLI interface
     "jsonschema>=4.0.0",   # Schema validation
-    # Capped below 2.0: it removes the decorator registration API
-    # (@server.list_tools() and friends) that rmcp/core/sdk_adapter.py is
-    # built on, so the server raises AttributeError on startup and does not
-    # run at all. Supporting 2.x means rewriting the adapter.
-    "mcp>=1.28.1,<2",      # Official MCP SDK (protocol, stdio + Streamable HTTP)
+    "mcp>=2,<3",           # Official MCP SDK (protocol, stdio + Streamable HTTP)
     "psutil>=5.0.0",       # R process management
     "uvicorn>=0.31.1",     # ASGI server for the Streamable HTTP transport
     "structlog>=23.1.0",   # Structured logging for MCP observability

--- a/rmcp/core/sdk_adapter.py
+++ b/rmcp/core/sdk_adapter.py
@@ -10,18 +10,14 @@ low-level ``Server`` so that protocol lifecycle, capabilities, and transports
 from __future__ import annotations
 
 import asyncio
-import base64
 import contextlib
 import logging
 import uuid
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import mcp.types as types
 from mcp.server.lowlevel import NotificationOptions, Server
-from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.models import InitializationOptions
-from pydantic import AnyUrl
 
 from ..logging_config import set_request_id
 from .context import Context
@@ -77,36 +73,46 @@ class SDKServerAdapter:
 
     def __init__(self, rmcp_server: MCPServer):
         self.rmcp_server = rmcp_server
+        # Sessions that issued resources/subscribe
+        self._subscribed_sessions: set[Any] = set()
+        # mcp 2.x takes handlers as constructor arguments; the decorator
+        # registration API (@server.list_tools() and friends) was removed.
         self.sdk_server: Server = _RMCPSDKServer(
             name=rmcp_server.name,
             version=rmcp_server.version,
             instructions=rmcp_server.description or None,
+            on_list_tools=self._on_list_tools,
+            on_call_tool=self._on_call_tool,
+            on_list_resources=self._on_list_resources,
+            on_list_resource_templates=self._on_list_resource_templates,
+            on_read_resource=self._on_read_resource,
+            on_subscribe_resource=self._on_subscribe_resource,
+            on_unsubscribe_resource=self._on_unsubscribe_resource,
+            on_list_prompts=self._on_list_prompts,
+            on_get_prompt=self._on_get_prompt,
+            on_set_logging_level=self._on_set_logging_level,
         )
-        # Sessions that issued resources/subscribe
-        self._subscribed_sessions: set[Any] = set()
-        self._register_handlers()
         rmcp_server.add_list_changed_listener(self._on_list_changed)
 
     # ------------------------------------------------------------------
     # Context plumbing
     # ------------------------------------------------------------------
-    def _create_context(self, method: str) -> Context:
-        """Create an RMCP context whose feedback flows through the SDK session."""
-        session = None
-        request_id = str(uuid.uuid4())
-        progress_token: str | int | None = None
-        try:
-            rc = self.sdk_server.request_context
-            session = rc.session
-            request_id = str(rc.request_id)
-            if rc.meta is not None:
-                progress_token = rc.meta.progressToken
-        except LookupError:
-            pass
+    def _create_context(self, ctx: Any, method: str) -> Context:
+        """Create an RMCP context whose feedback flows through the SDK session.
 
-        # Publish it so every line logged while serving this request carries it.
-        # asyncio copies the context into child tasks, so the R execution under
-        # a tool call is correlatable with the call itself.
+        mcp 2.x hands the request context to the handler, so there is no
+        contextvar lookup to fail; ``ctx`` is always present.
+        """
+        session = getattr(ctx, "session", None)
+        request_id = str(getattr(ctx, "request_id", None) or uuid.uuid4())
+        progress_token: str | int | None = None
+        meta = getattr(ctx, "meta", None)
+        if meta is not None:
+            progress_token = getattr(meta, "progressToken", None)
+
+        # Publish these so every line logged while serving this request carries
+        # them. asyncio copies the context into child tasks, so the R execution
+        # under a tool call is correlatable with the call itself.
         set_request_id(request_id)
 
         async def progress_callback(message: str, current: int, total: int) -> None:
@@ -159,126 +165,145 @@ class SDKServerAdapter:
 
     # ------------------------------------------------------------------
     # Handlers
+    #
+    # mcp 2.x hands each handler ``(ctx, params)`` and expects a typed result,
+    # where 1.x passed unpacked arguments and accepted bare lists.
     # ------------------------------------------------------------------
-    def _register_handlers(self) -> None:
-        sdk = self.sdk_server
-        rmcp = self.rmcp_server
+    async def _on_list_tools(
+        self, ctx: Any, params: Any = None
+    ) -> types.ListToolsResult:
+        context = self._create_context(ctx, "tools/list")
+        try:
+            cursor = getattr(params, "cursor", None) if params is not None else None
+            result = await self.rmcp_server.tools.list_tools(context, cursor=cursor)
+            return types.ListToolsResult.model_validate(result)
+        finally:
+            self._finish(context)
 
-        @sdk.list_tools()
-        async def list_tools(req: types.ListToolsRequest) -> types.ListToolsResult:
-            context = self._create_context("tools/list")
-            try:
-                cursor = req.params.cursor if req is not None and req.params else None
-                result = await rmcp.tools.list_tools(context, cursor=cursor)
-                return types.ListToolsResult.model_validate(result)
-            finally:
-                self._finish(context)
+    async def _on_call_tool(self, ctx: Any, params: Any) -> types.CallToolResult:
+        # Input validation stays in the registry, for a single error shape.
+        context = self._create_context(ctx, "tools/call")
+        try:
+            result = await self.rmcp_server.tools.call_tool(
+                context, params.name, params.arguments or {}
+            )
+            return types.CallToolResult.model_validate(result)
+        except Exception as exc:
+            # The registry converts handler failures to isError itself, but an
+            # unknown tool raises before that. 1.x's decorator turned it into an
+            # isError result; 2.x would propagate it as a protocol error. Keep
+            # the shape clients already see.
+            return types.CallToolResult(
+                content=[types.TextContent(type="text", text=str(exc))],
+                isError=True,
+            )
+        finally:
+            self._finish(context)
 
-        # Input validation is handled by the registry (single error shape).
-        @sdk.call_tool(validate_input=False)
-        async def call_tool(
-            name: str, arguments: dict[str, Any]
-        ) -> types.CallToolResult:
-            context = self._create_context("tools/call")
-            try:
-                result = await rmcp.tools.call_tool(context, name, arguments)
-                return types.CallToolResult.model_validate(result)
-            finally:
-                self._finish(context)
+    async def _on_list_resources(
+        self, ctx: Any, params: Any = None
+    ) -> types.ListResourcesResult:
+        context = self._create_context(ctx, "resources/list")
+        try:
+            cursor = getattr(params, "cursor", None) if params is not None else None
+            result = await self.rmcp_server.resources.list_resources(
+                context, cursor=cursor
+            )
+            # URI templates are exposed via resources/templates/list instead.
+            entries = [
+                entry
+                for entry in result.get("resources", [])
+                if "{" not in entry.get("uri", "")
+            ]
+            payload: dict[str, Any] = {"resources": entries}
+            if result.get("nextCursor") is not None:
+                payload["nextCursor"] = result["nextCursor"]
+            return types.ListResourcesResult.model_validate(payload)
+        finally:
+            self._finish(context)
 
-        @sdk.list_resources()
-        async def list_resources(
-            req: types.ListResourcesRequest,
-        ) -> types.ListResourcesResult:
-            context = self._create_context("resources/list")
-            try:
-                cursor = req.params.cursor if req is not None and req.params else None
-                result = await rmcp.resources.list_resources(context, cursor=cursor)
-                # URI templates are exposed via resources/templates/list instead.
-                entries = [
-                    entry
-                    for entry in result.get("resources", [])
-                    if "{" not in entry.get("uri", "")
-                ]
-                payload: dict[str, Any] = {"resources": entries}
-                if result.get("nextCursor") is not None:
-                    payload["nextCursor"] = result["nextCursor"]
-                return types.ListResourcesResult.model_validate(payload)
-            finally:
-                self._finish(context)
-
-        @sdk.list_resource_templates()
-        async def list_resource_templates() -> list[types.ResourceTemplate]:
-            return [
+    async def _on_list_resource_templates(
+        self, ctx: Any, params: Any = None
+    ) -> types.ListResourceTemplatesResult:
+        return types.ListResourceTemplatesResult(
+            resourceTemplates=[
                 types.ResourceTemplate(
                     uriTemplate=uri_template,
                     name=meta.get("name", uri_template),
                     description=meta.get("description"),
                 )
-                for uri_template, meta in sorted(rmcp.resources.iter_templates())
+                for uri_template, meta in sorted(
+                    self.rmcp_server.resources.iter_templates()
+                )
             ]
+        )
 
-        @sdk.read_resource()
-        async def read_resource(uri: AnyUrl) -> Iterable[ReadResourceContents]:
-            context = self._create_context("resources/read")
-            try:
-                result = await rmcp.resources.read_resource(context, str(uri))
-                contents: list[ReadResourceContents] = []
-                for item in result.get("contents", []):
-                    mime_type = item.get("mimeType")
-                    if "blob" in item:
-                        data: str | bytes = base64.b64decode(item["blob"])
-                    else:
-                        data = item.get("text", "")
-                    contents.append(
-                        ReadResourceContents(content=data, mime_type=mime_type)
-                    )
-                return contents
-            finally:
-                self._finish(context)
+    async def _on_read_resource(
+        self, ctx: Any, params: Any
+    ) -> types.ReadResourceResult:
+        context = self._create_context(ctx, "resources/read")
+        try:
+            result = await self.rmcp_server.resources.read_resource(
+                context, str(params.uri)
+            )
+            contents: list[Any] = []
+            for item in result.get("contents", []):
+                entry: dict[str, Any] = {"uri": item.get("uri", str(params.uri))}
+                if item.get("mimeType"):
+                    entry["mimeType"] = item["mimeType"]
+                if "blob" in item:
+                    entry["blob"] = item["blob"]
+                else:
+                    entry["text"] = item.get("text", "")
+                contents.append(entry)
+            return types.ReadResourceResult.model_validate({"contents": contents})
+        finally:
+            self._finish(context)
 
-        @sdk.subscribe_resource()
-        async def subscribe_resource(uri: AnyUrl) -> None:
-            with contextlib.suppress(LookupError):
-                self._subscribed_sessions.add(sdk.request_context.session)
+    async def _on_subscribe_resource(self, ctx: Any, params: Any) -> types.EmptyResult:
+        session = getattr(ctx, "session", None)
+        if session is not None:
+            self._subscribed_sessions.add(session)
+        return types.EmptyResult()
 
-        @sdk.unsubscribe_resource()
-        async def unsubscribe_resource(uri: AnyUrl) -> None:
-            with contextlib.suppress(LookupError):
-                self._subscribed_sessions.discard(sdk.request_context.session)
+    async def _on_unsubscribe_resource(
+        self, ctx: Any, params: Any
+    ) -> types.EmptyResult:
+        session = getattr(ctx, "session", None)
+        if session is not None:
+            self._subscribed_sessions.discard(session)
+        return types.EmptyResult()
 
-        @sdk.list_prompts()
-        async def list_prompts(
-            req: types.ListPromptsRequest,
-        ) -> types.ListPromptsResult:
-            context = self._create_context("prompts/list")
-            try:
-                cursor = req.params.cursor if req is not None and req.params else None
-                result = await rmcp.prompts.list_prompts(context, cursor=cursor)
-                prompts = [
-                    _convert_prompt_entry(entry) for entry in result.get("prompts", [])
-                ]
-                payload: dict[str, Any] = {"prompts": prompts}
-                if result.get("nextCursor") is not None:
-                    payload["nextCursor"] = result["nextCursor"]
-                return types.ListPromptsResult.model_validate(payload)
-            finally:
-                self._finish(context)
+    async def _on_list_prompts(
+        self, ctx: Any, params: Any = None
+    ) -> types.ListPromptsResult:
+        context = self._create_context(ctx, "prompts/list")
+        try:
+            cursor = getattr(params, "cursor", None) if params is not None else None
+            result = await self.rmcp_server.prompts.list_prompts(context, cursor=cursor)
+            prompts = [
+                _convert_prompt_entry(entry) for entry in result.get("prompts", [])
+            ]
+            payload: dict[str, Any] = {"prompts": prompts}
+            if result.get("nextCursor") is not None:
+                payload["nextCursor"] = result["nextCursor"]
+            return types.ListPromptsResult.model_validate(payload)
+        finally:
+            self._finish(context)
 
-        @sdk.get_prompt()
-        async def get_prompt(
-            name: str, arguments: dict[str, str] | None
-        ) -> types.GetPromptResult:
-            context = self._create_context("prompts/get")
-            try:
-                result = await rmcp.prompts.get_prompt(context, name, arguments or {})
-                return types.GetPromptResult.model_validate(result)
-            finally:
-                self._finish(context)
+    async def _on_get_prompt(self, ctx: Any, params: Any) -> types.GetPromptResult:
+        context = self._create_context(ctx, "prompts/get")
+        try:
+            result = await self.rmcp_server.prompts.get_prompt(
+                context, params.name, params.arguments or {}
+            )
+            return types.GetPromptResult.model_validate(result)
+        finally:
+            self._finish(context)
 
-        @sdk.set_logging_level()
-        async def set_logging_level(level: types.LoggingLevel) -> None:
-            await rmcp._handle_set_log_level(level)
+    async def _on_set_logging_level(self, ctx: Any, params: Any) -> types.EmptyResult:
+        await self.rmcp_server._handle_set_log_level(params.level)
+        return types.EmptyResult()
 
     # ------------------------------------------------------------------
     # Notifications

--- a/rmcp/core/server.py
+++ b/rmcp/core/server.py
@@ -44,8 +44,20 @@ except Exception:  # pragma: no cover - optional dependency
         "alert",
         "emergency",
     ]
-# Supported MCP protocol versions (latest first)
-_SUPPORTED_PROTOCOL_VERSIONS = tuple(dict.fromkeys((_PROTOCOL_VERSION, "2025-06-18")))
+# Take the SDK's own list rather than hand-maintaining entries. Building it as
+# (latest, "2025-06-18") silently dropped whichever versions the SDK gained in
+# between -- under mcp 2.x that meant losing 2025-11-25, which current clients
+# negotiate.
+try:
+    from mcp.types.version import (  # type: ignore
+        SUPPORTED_PROTOCOL_VERSIONS as _SDK_PROTOCOL_VERSIONS,
+    )
+
+    _SUPPORTED_PROTOCOL_VERSIONS = tuple(_SDK_PROTOCOL_VERSIONS)
+except Exception:  # pragma: no cover - SDK layout differs
+    _SUPPORTED_PROTOCOL_VERSIONS = tuple(
+        dict.fromkeys((_PROTOCOL_VERSION, "2025-11-25", "2025-06-18"))
+    )
 
 # Import version from __init__ at runtime to avoid circular imports
 from ..registries.prompts import PromptsRegistry

--- a/scripts/setup/ide_integrations.py
+++ b/scripts/setup/ide_integrations.py
@@ -352,7 +352,7 @@ class TestRMCPServerSetup:
         except Exception as e:
             pytest.fail(f"Sample analysis failed: {e}")
 
-        assert not result.isError, f"Sample analysis returned error: {result.content}"
+        assert not result.is_error, f"Sample analysis returned error: {result.content}"
         print("Sample analysis successful")
 
 

--- a/tests/unit/core/test_sdk_adapter.py
+++ b/tests/unit/core/test_sdk_adapter.py
@@ -1,14 +1,46 @@
 """End-to-end tests of the SDK adapter using the official in-memory client."""
 
+import contextlib
+
+import anyio
 import mcp.types as types
 import pytest
-from mcp.shared.memory import create_connected_server_and_client_session
+from mcp import ClientSession
+from mcp.shared.memory import create_client_server_memory_streams
 from rmcp.core.sdk_adapter import build_sdk_server
 from rmcp.core.server import create_server
 from rmcp.registries.prompts import (
     register_prompt_functions,
     statistical_workflow_prompt,
 )
+
+
+@contextlib.asynccontextmanager
+async def create_connected_server_and_client_session(server):
+    """In-memory client wired to `server`.
+
+    Replaces mcp 1.x's helper of the same name, removed in 2.x.
+    """
+    async with create_client_server_memory_streams() as (
+        (client_read, client_write),
+        (server_read, server_write),
+    ):
+        async with anyio.create_task_group() as tg:
+
+            async def _serve() -> None:
+                with contextlib.suppress(Exception):
+                    await server.run(
+                        server_read,
+                        server_write,
+                        server.create_initialization_options(),
+                        raise_exceptions=True,
+                    )
+
+            tg.start_soon(_serve)
+            async with ClientSession(client_read, client_write) as session:
+                await session.initialize()
+                yield session
+            tg.cancel_scope.cancel()
 
 
 def _make_server(tmp_path):
@@ -68,7 +100,7 @@ async def test_initialize_and_capabilities(rmcp_server):
     assert options.server_version == rmcp_server.version
     caps = options.capabilities
     assert caps.tools is not None
-    assert caps.resources is not None and caps.resources.listChanged
+    assert caps.resources is not None and caps.resources.list_changed
     assert caps.prompts is not None
     assert caps.logging is not None
 
@@ -84,12 +116,12 @@ async def test_list_and_call_tool(rmcp_server):
         echo = next(tool for tool in tools.tools if tool.name == "echo")
         # outputSchema is not advertised: it dominated the tools/list payload
         # without telling the model anything the first result doesn't.
-        assert echo.outputSchema is None
+        assert echo.output_schema is None
 
         result = await session.call_tool("echo", {"message": "hello"})
-        assert result.isError is not True
+        assert result.is_error is not True
         # ...but results are still validated against it server-side
-        assert result.structuredContent == {"echoed": "hello", "length": 5}
+        assert result.structured_content == {"echoed": "hello", "length": 5}
 
 
 async def test_call_tool_error_shape(rmcp_server):
@@ -98,11 +130,11 @@ async def test_call_tool_error_shape(rmcp_server):
         adapter.sdk_server
     ) as session:
         result = await session.call_tool("always_fails", {})
-        assert result.isError is True
+        assert result.is_error is True
         assert "deliberate failure" in result.content[0].text
 
         unknown = await session.call_tool("does_not_exist", {})
-        assert unknown.isError is True
+        assert unknown.is_error is True
 
 
 async def test_input_validation_error(rmcp_server):
@@ -111,7 +143,7 @@ async def test_input_validation_error(rmcp_server):
         adapter.sdk_server
     ) as session:
         result = await session.call_tool("echo", {"message": 42})
-        assert result.isError is True
+        assert result.is_error is True
 
 
 async def test_list_tools_pagination(rmcp_server):
@@ -119,14 +151,10 @@ async def test_list_tools_pagination(rmcp_server):
     async with create_connected_server_and_client_session(
         adapter.sdk_server
     ) as session:
-        first = await session.send_request(
-            types.ClientRequest(
-                types.ListToolsRequest(
-                    method="tools/list",
-                    params=types.PaginatedRequestParams(cursor=None),
-                )
-            ),
-            types.ListToolsResult,
+        # ClientRequest is a union in mcp 2.x, so raw request construction is
+        # gone; the client takes pagination params directly.
+        first = await session.list_tools(
+            params=types.PaginatedRequestParams(cursor=None)
         )
         assert len(first.tools) >= 2
 
@@ -161,7 +189,7 @@ async def test_resources_round_trip(rmcp_server):
         assert any(uri.startswith("rmcp://") for uri in uris)
 
         templates = await session.list_resource_templates()
-        template_uris = [t.uriTemplate for t in templates.resourceTemplates]
+        template_uris = [t.uri_template for t in templates.resource_templates]
         assert "rmcp://dataset/{name}" in template_uris
 
         readme = await session.read_resource("rmcp://docs/readme")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,9 +37,9 @@ def run_mcp_stdio_workflow(
                 call_results = []
                 for name, arguments in tool_calls or []:
                     result = await session.call_tool(name, arguments)
-                    call_results.append(result.model_dump(mode="json"))
+                    call_results.append(result.model_dump(mode="json", by_alias=True))
                 return (
-                    init.model_dump(mode="json"),
+                    init.model_dump(mode="json", by_alias=True),
                     [tool.name for tool in tools.tools],
                     call_results,
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -526,6 +526,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -541,12 +554,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -560,11 +580,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -724,15 +744,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -742,9 +762,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -883,6 +916,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1132,20 +1177,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pydoclint"
 version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1247,15 +1278,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1434,7 +1456,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.25.0" },
     { name = "httpx", marker = "extra == 'http'", specifier = ">=0.25.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
-    { name = "mcp", specifier = ">=1.28.1,<2" },
+    { name = "mcp", specifier = ">=2,<3" },
     { name = "openpyxl", marker = "extra == 'all'", specifier = ">=3.0.0" },
     { name = "openpyxl", marker = "extra == 'http'", specifier = ">=3.0.0" },
     { name = "pandas", marker = "extra == 'all'", specifier = ">=1.5.0" },
@@ -1832,6 +1854,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #52. mcp 2.0 removed the decorator registration API the adapter was built on, so 0.10.1 pinned `<2` as a stopgap. This ports the adapter and removes the cap.

## The port

2.x takes handlers as **constructor arguments** rather than decorators, and every one rmcp used has a direct counterpart — all ten map 1:1. Each handler body still changes: signatures become `(ctx, params)` and handlers return typed results instead of the bare lists 1.x accepted. `_create_context` now receives the context rather than reaching for a contextvar, which removes its `LookupError` fallback entirely.

## Clients see no protocol change

This was the risk worth checking directly rather than inferring. Initialising against every version the SDK supports:

```
client 2024-11-05 -> server 2024-11-05
client 2025-03-26 -> server 2025-03-26
client 2025-06-18 -> server 2025-06-18
client 2025-11-25 -> server 2025-11-25
client 2026-07-28 -> server 2025-11-25
```

Every legacy version negotiates to itself, and even a 2026-07-28 client gets 2025-11-25 back, because the classic handshake tops out there. **Adopting 2.x does not move the protocol rmcp actually speaks.**

## Two behaviours preserved deliberately

- **Unknown tool.** It raises before the registry's `try`, so 1.x's decorator turned it into an `isError` result while 2.x would propagate a protocol error. The adapter now catches it — a port shouldn't silently change what clients see.
- **`_SUPPORTED_PROTOCOL_VERSIONS`** was hand-built as `(latest, "2025-06-18")`, which under 2.x silently drops `2025-11-25` — the version current clients negotiate. It now takes the SDK's own list instead of hand-maintaining entries.

## Test changes are all one cause

2.x renamed model fields to snake_case, keeping camelCase only as wire aliases. So `tests/utils.py` dumps `by_alias=True` (its dicts represent wire messages), and direct attribute access follows the new names. Separately, 2.x dropped `create_connected_server_and_client_session`, rebuilt locally from the memory-stream primitives that remain; and `ClientRequest` became a union, so the pagination test uses the client's own API.

**301 passing**, same as before the port. stdout stays pure JSON-RPC on both stdio commands; zero notification failures, so `ctx.session` works.

## Correction: session_id is not wired

The plan said I'd wire `session_id`, on my claim that 2.x exposes `ctx.session_id`. **That was wrong.** I'd read the property from the SDK source without checking it's on the class handlers actually receive — it isn't, and the session object carries no id either:

```
ctx attrs: ['close_sse_stream', 'close_standalone_sse_stream', 'lifespan_context',
            'meta', 'method', 'params', 'protocol_version', 'request', 'request_id', 'session']
```

The transport session id exists at the HTTP layer but is not reachable from a handler. I implemented it, saw it emit `session_id: None` on every line, and reverted — an always-null field is worse than an absent one, which is the same reason it was left out under 1.x.

## Noted, not addressed

2.x deprecates the logging capability (SEP-2577), which rmcp still advertises. Not breaking yet, but it will be removed eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)