### PR TITLE
Fall back to main's image when a PR builds none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,14 @@ jobs:
           changed_files=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
           echo "Changed files: $changed_files"
 
-          # Files that require Docker rebuild
+          # Files that require Docker rebuild. uv.lock belongs here because the
+          # image now copies it and installs with `uv sync --frozen`, so a
+          # dependency bump changes what the image contains.
           docker_relevant_files=(
             "Dockerfile"
             "Dockerfile.base"
             "pyproject.toml"
+            "uv.lock"
             "rmcp/"
             ".github/workflows/ci.yml"
           )
@@ -244,8 +247,13 @@ jobs:
       id: image
       env:
         PR_NUMBER: ${{ github.event.number }}
+        SHOULD_BUILD: ${{ steps.check-changes.outputs.should_build }}
       run: |
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
+        # Prefer this PR's own image, but only when the run actually built and
+        # pushed it -- otherwise the pr-<n> tag does not exist and the pull
+        # fails. Falling back to main's `latest` is the only sensible image for
+        # a PR that changed nothing image-relevant.
+        if [ "${{ github.event_name }}" = "pull_request" ] && [ "$SHOULD_BUILD" = "true" ]; then
           tag="pr-${PR_NUMBER}"
         else
           tag="latest"
@@ -257,8 +265,9 @@ jobs:
       id: prod-image
       env:
         PR_NUMBER: ${{ github.event.number }}
+        SHOULD_BUILD: ${{ steps.check-changes.outputs.should_build }}
       run: |
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
+        if [ "${{ github.event_name }}" = "pull_request" ] && [ "$SHOULD_BUILD" = "true" ]; then
           tag="pr-${PR_NUMBER}-production"
         else
           tag="production-latest"


### PR DESCRIPTION
Fixes two regressions from my own earlier CI changes. PR #47 (`dependabot/uv/pandas-3.0.3`) is red because of them.

## 1. Missing fallback

Pointing PR jobs at `pr-<n>` images fixed something real — PR runs were silently testing **main's** images, which is why PR #50 passed while main went red minutes later. But those tags only exist when `docker-build` actually runs:

```
Changed files: uv.lock
⏭️  Skipping: No Docker-relevant files changed
❌ Failed to pull production image: .../rmcp-ci:pr-47-production
```

So I'd traded a silent-wrong-signal bug for a hard-failure one. The `pr-<n>` tag is now used **only when the run built it**, falling back to `latest` otherwise. A PR that rebuilds images still tests its own.

## 2. `uv.lock` wasn't a rebuild trigger

I made the image copy `uv.lock` and install with `uv sync --frozen`, so images stop floating off the lock. That also makes the lock image-relevant — but it was never added to `docker_relevant_files`. A dependency bump therefore changes what the image would contain **without rebuilding it**. That's exactly PR #47's case and why it had no image to pull.

Either fix alone is insufficient: adding `uv.lock` makes #47 rebuild, but PRs touching nothing image-relevant still need the fallback.

## Verified

Both branches of the tag logic, against the actual shell:

```
event=pull_request  should_build=true  -> pr-47
event=pull_request  should_build=false -> latest
event=push          should_build=*     -> latest
```

And both diff cases: a lock-only diff now reports `Building: uv.lock changed`; a docs-only diff still yields `should_build=false`.

## Also in flight

`main`'s red run (30421827876, the 0.11.0 changelog commit) is unrelated — `Install uv: fetch failed` on windows-3.11, with two jobs cancelled by fail-fast. Infrastructure flake, re-run triggered separately. The preceding main run was green.

No package impact — workflow-only, so no release. 0.11.0 stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)