### PR TITLE
Stop an apt mirror hiccup from failing a required job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,8 +445,32 @@ jobs:
         pytest tests/scenarios/ -v --tb=short --cov=rmcp --cov-append
 
     - name: Install gpg for Codecov uploader verification
+      # Best-effort by design. The only thing that wants gpg is the Codecov
+      # upload below, and that step already runs with fail_ci_if_error: false
+      # -- so a required job was hard-failing on a helper for an upload that
+      # is itself allowed to fail. The criticality was inverted.
+      #
+      # Not hypothetical. On 5 August this step failed with
+      #   E: Failed to fetch .../noble-cran40/Packages.gz
+      #      File has unexpected size (62232 != 61419). Mirror sync in progress?
+      # *after* the tests had already passed. Because "R Integration & Workflow
+      # Tests" is a required context, that mirror hiccup blocked PR #66 -- a
+      # security bump closing an open advisory -- for five days.
+      #
+      # Retries cover a mirror mid-sync, which clears in minutes.
+      # continue-on-error covers the case where it does not.
+      continue-on-error: true
       run: |
-        apt-get update -qq && apt-get install -y -qq gpg
+        set -u
+        for attempt in 1 2 3; do
+          if apt-get update -qq && apt-get install -y -qq gpg; then
+            echo "gpg installed on attempt $attempt"
+            exit 0
+          fi
+          echo "::warning::apt failed on attempt $attempt; retrying"
+          sleep $((attempt * 10))
+        done
+        echo "::warning::could not install gpg; the Codecov upload proceeds unverified"
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7


### PR DESCRIPTION
On 5 August the `R Integration & Workflow Tests` job failed with:

```
E: Failed to fetch https://cloud.r-project.org/bin/linux/ubuntu/noble-cran40/Packages.gz
   File has unexpected size (62232 != 61419). Mirror sync in progress?
```

The tests had already passed — `17 passed, 29 skipped`. What failed was a later step doing `apt-get update` while the CRAN mirror was mid-sync.

Because that job is a **required context**, the failure blocked #66 — a `virtualenv` bump closing an open security advisory — for **five days**. It only landed today once the checks were re-run.

## The actual defect is inverted criticality

The step exists solely to install `gpg` so the Codecov uploader can verify its own signature. The very next step is:

```yaml
    - name: Upload coverage to Codecov
      uses: codecov/codecov-action@v7
      with:
        fail_ci_if_error: false      # <-- already tolerant
```

So a required job was hard-failing on a helper for an upload that is **explicitly allowed to fail**. Retrying alone would treat the symptom; the step should not have been able to fail the job in the first place.

## The fix

Both halves, because they cover different cases:

- **Bounded retry** (3 attempts, 10s/20s backoff) — covers a mirror mid-sync, which clears in minutes. This is the common case and worth actually recovering from rather than skipping.
- **`continue-on-error: true`** — covers the case where it does not clear. Coverage upload quality is not worth a red required check.

Failures still surface as `::warning::` annotations, so a persistent apt problem stays visible instead of vanishing. If gpg genuinely cannot be installed, the Codecov upload proceeds unverified and says so.

## Verification

- `actionlint` finding count is **10 before and 10 after** this change — the new step adds none. (Those 10 are pre-existing `SC2086`/`SC2015`/`SC2034` infos elsewhere in the file, untouched here; nothing in CI gates on them today.)
- The inline script passes `sh -n`. It stays POSIX — this step runs in a container where the default shell is `sh -e`, not bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)