### PR TITLE
Record the py-canon fleet exemption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,3 +218,11 @@ DEP004 = ["pytest", "numpy"]           # Dev dependencies in scripts/streamlit
 [tool.deptry.package_module_name_map]
 structlog = "structlog"
 linkify-it-py = "linkify_it_py"
+
+[tool.preen]
+# Fleet exemption (decided 2026-08-18): rmcp is an MCP server whose real gate
+# is its own CI — Python lint/tests plus R integration and Docker scenario
+# tests that canon's reusable-ci matrix cannot express. It stays in py-canon's
+# FLEET for monitoring but does not adopt the copier template or the shared
+# workflow layer. See py-canon docs/fleet-inventory.md.
+skip_checks = ["template", "workflows", "ci-matrix"]


### PR DESCRIPTION
Makes the fleet-inventory 'exempt' tier decision (confirmed 2026-08-18) machine-readable: a `[tool.preen]` block with `skip_checks` for the canon-machinery checks and the rationale in place. rmcp stays in FLEET for monitoring; its own CI (Python lint/tests, R integration, Docker scenarios) remains the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)