### PR TITLE
Rename citation.cff so GitHub can read it, and cite the current version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
 title: "RMCP: R Model Context Protocol Server"
-version: "0.7.0"
-date-released: "2025-08-20"
+version: "0.12.0"
+date-released: "2026-08-17"
 url: "https://github.com/finite-sample/rmcp"
 repository-code: "https://github.com/finite-sample/rmcp"
 abstract: "A Model Context Protocol (MCP) server that provides comprehensive statistical analysis capabilities through R. Features 40 statistical analysis tools across 9 categories, enabling AI assistants to perform sophisticated statistical modeling, econometric analysis, machine learning, time series analysis, and data science tasks through natural conversation."


### PR DESCRIPTION
Two problems in one file, both found by `preen check` sweeping the fleet.

## The filename

This repo ships **`citation.cff`**. GitHub reads `CITATION.cff` and no other spelling, so the "Cite this repository" button has never appeared here — and a case-sensitive checkout (any Linux CI runner) does not see the file at all. It only looked fine because macOS resolves the exact name to it.

`git mv citation.cff CITATION.cff`, which shows as a rename in the diff.

This one caught preen out too: the check was reading and would have happily rewritten a file GitHub never sees. Fixed in gojiplus/preen#70, which now reports a non-canonical spelling as its own finding.

## The version

```diff
-version: "0.7.0"
-date-released: "2025-08-20"
+version: "0.12.0"
+date-released: "2026-08-17"
```

`project.version` is `0.12.0`, tagged 2026-08-17. Whoever cites this package copies the number in this file. Applied with `preen fix citation`, which moves `date-released` with the version rather than leaving a right version beside a wrong date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SkMDqnEFUgr7Mbc1HwMqX