### PR TITLE
Configure pytest to fail on what it should fail on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = [
-    "-v",
-    "--strict-markers",
-    "--strict-config",
-]
+addopts = ["-v", "--strict-markers", "--strict-config", "-ra"]
 filterwarnings = [
     # A test that returns instead of asserting silently passes no matter what
     # it computed. Make that a hard failure rather than a warning.
@@ -117,6 +113,9 @@ markers = [
     "asyncio: marks tests as async",
     "local: marks tests that require local IDE setup (not run in CI)",
 ]
+minversion = "6"
+log_level = "INFO"
+xfail_strict = true
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
py-canon 1.3.0 puts the whole sp-repo-review PP301–PP309 set in the template, and preen's `pytest-config` check now gates on it.

```toml
minversion, log_level, xfail_strict, filterwarnings = ["error"]
addopts: -ra, --strict-config, --strict-markers
```

These decide whether a run **fails**, not how it reads. Without `filterwarnings` a dependency's DeprecationWarning stays invisible until the release that removes the API; without `--strict-markers` a typo in a marker name selects nothing and reports success; without `--strict-config` a typo in this very table is ignored.

Applied with `preen fix pytest-config`. **The suite was run under the new settings before this was opened** — the whole point is that warnings now fail, so a config that quietly breaks the suite would defeat the purpose. Anything that needed a scoped ignore or a real fix got one, and is described above if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)